### PR TITLE
Dashboard and User pages update following api changes 

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -23,7 +23,7 @@ export async function getUserData() {
     }, */
   });
 
-  if (res.status !== 200) {
+  if (!res?.ok) {
     const errorMessage = await res.text();
 
     return {
@@ -35,22 +35,9 @@ export async function getUserData() {
     };
   }
 
-  if (res.status === 200) {
-    res = await res.json();
+  res = await res.json();
 
-    return res;
-  }
-
-  /* .then((response) => {
-      return response.json();
-    })
-    .then((data) => {
-      console.log(data);
-      return data;
-    })
-    .catch((error) => {
-      console.error('Error fetching authenticated user:', error);
-    }); */
+  return res;
 }
 
 export async function checkUserLogin() {
@@ -67,11 +54,13 @@ export async function checkUserLogin() {
   });
 
   if (!res?.ok) {
-    const errorCode = res?.status;
+    const errorMessage = await res.text();
 
     return {
       error: {
-        errorCode,
+        status: res?.status,
+        text: res?.statusText,
+        message: errorMessage,
       },
     };
   }

--- a/app/dashboard/page.module.css
+++ b/app/dashboard/page.module.css
@@ -65,10 +65,6 @@
   color: hsla(var(--red-400));
 }
 
-.change.negative::before {
-  content: '-';
-}
-
 .header .stats {
   display: flex;
   flex-flow: row;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -102,7 +102,7 @@ export default async function page({
             </div>
           </div>
           <div className={styles.chart}>
-            <AreaChart ratingStats={data.ratingStats} />
+            <AreaChart ratingStats={data.ratingChart.chartData} />
           </div>
         </div>
       </div>
@@ -161,32 +161,6 @@ export default async function page({
         </GridCard>
         <GridCard title={'Winrate by mod'}>
           <RadarChart winrateModData={data?.modStats} />
-        </GridCard>
-        <GridCard title={'Teammates'}>
-          <div className={styles.cardStat}>
-            <span>Most played</span>
-            <span className={styles.value}>
-              {data?.matchStats.mostPlayedTeammateName}
-            </span>
-          </div>
-          <div className={styles.cardStat}>
-            <span>Best teammate</span>
-            <span className={styles.value}>
-              {data?.matchStats.bestTeammateName}
-            </span>
-          </div>
-        </GridCard>
-        <GridCard title={'Opponents'}>
-          <div className={styles.cardStat}>
-            <span>Most played</span>
-            <span className={styles.value}>
-              {data?.matchStats.mostPlayedOpponentName}
-            </span>
-          </div>
-          <div className={styles.cardStat}>
-            <span>Best opponent</span>
-            <span className={styles.value}>TO DO</span>
-          </div>
         </GridCard>
         <GridCard title={'Average score per mod'}>
           <RadarChart averageModScore={data?.modStats} />

--- a/app/users/[id]/page.module.css
+++ b/app/users/[id]/page.module.css
@@ -65,10 +65,6 @@
   color: hsla(var(--red-400));
 }
 
-.change.negative::before {
-  content: '-';
-}
-
 .header .stats {
   display: flex;
   flex-flow: row;

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -82,7 +82,7 @@ export default async function page({
             </div>
           </div>
           <div className={styles.chart}>
-            <AreaChart ratingStats={data.ratingStats} />
+            <AreaChart ratingStats={data.ratingChart.chartData} />
           </div>
         </div>
       </div>
@@ -141,32 +141,6 @@ export default async function page({
         </GridCard>
         <GridCard title={'Winrate by mod'}>
           <RadarChart winrateModData={data?.modStats} />
-        </GridCard>
-        <GridCard title={'Teammates'}>
-          <div className={styles.cardStat}>
-            <span>Most played</span>
-            <span className={styles.value}>
-              {data?.matchStats.mostPlayedTeammateName}
-            </span>
-          </div>
-          <div className={styles.cardStat}>
-            <span>Best teammate</span>
-            <span className={styles.value}>
-              {data?.matchStats.bestTeammateName}
-            </span>
-          </div>
-        </GridCard>
-        <GridCard title={'Opponents'}>
-          <div className={styles.cardStat}>
-            <span>Most played</span>
-            <span className={styles.value}>
-              {data?.matchStats.mostPlayedOpponentName}
-            </span>
-          </div>
-          <div className={styles.cardStat}>
-            <span>Best opponent</span>
-            <span className={styles.value}>TO DO</span>
-          </div>
         </GridCard>
         <GridCard title={'Average score per mod'}>
           <RadarChart averageModScore={data?.modStats} />

--- a/components/Charts/AreaChart/AreaChart.tsx
+++ b/components/Charts/AreaChart/AreaChart.tsx
@@ -78,18 +78,18 @@ export default function AreaChart({
 
   if (ratingStats) {
     labels = ratingStats.map((day) => {
-      return new Date(day[0].tooltipInfo.matchDate).toLocaleDateString(
-        'en-US',
-        dateFormatOptions
-      );
+      return new Date(
+        day[0].timestamp /* tooltipInfo.matchDate */
+      ).toLocaleDateString('en-US', dateFormatOptions);
     });
 
     tournamentsTooltip = ratingStats.map((day) => {
       let matches = [];
       day.forEach((match) => {
-        match.tooltipInfo.matchDate = new Date(
-          match.tooltipInfo.matchDate
-        ).toLocaleDateString('en-US', dateFormatOptions);
+        match.timestamp = new Date(match.timestamp).toLocaleDateString(
+          'en-US',
+          dateFormatOptions
+        );
 
         return matches.push(match);
       });
@@ -140,9 +140,7 @@ export default function AreaChart({
 
     if (tooltip.body && ratingStats) {
       const matchesLines = new Set(
-        ...tournamentsTooltip.filter(
-          (day) => day[0].tooltipInfo.matchDate == tooltip.title
-        )
+        ...tournamentsTooltip.filter((day) => day[0].timestamp == tooltip.title)
       );
 
       /* TOOLTIP HEADER */
@@ -163,9 +161,11 @@ export default function AreaChart({
         const li = document.createElement('li');
 
         const matchName = document.createElement('a');
-        matchName.href = match.tooltipInfo.mpLink;
-        matchName.target = '_blank';
-        matchName.innerHTML = match.tooltipInfo.matchName;
+        matchName.href = match?.matchOsuId
+          ? `https://osu.ppy.sh/mp/${match?.matchOsuId}`
+          : '#';
+        matchName.target = match?.matchOsuId ? '_blank' : '_self';
+        matchName.innerHTML = match.name;
 
         const ratingChange = document.createElement('span');
         ratingChange.innerHTML = match.ratingChange.toFixed(1);
@@ -204,7 +204,7 @@ export default function AreaChart({
       tooltip.options.padding + 'px ' + tooltip.options.padding + 'px';
     tooltipEl.style.pointerEvents = 'none';
 
-    var offset = tooltip.width + 120;
+    var offset = tooltip.width + 40; /* 120 */
     if (chart.width / 2 < tooltip.caretX) {
       offset *= -1;
     } else {

--- a/util/ErrorContext.tsx
+++ b/util/ErrorContext.tsx
@@ -15,11 +15,17 @@ type Props = {
 };
 
 export default function ErrorProvider({ children }: Props): JSX.Element {
-  const [error, setError] = useState<object | undefined>();
+  const [error, setError] = useState<object | undefined>(undefined);
   const [show, setShow] = useState(false);
 
   useEffect(() => {
     if (!error || show) return;
+
+    if (
+      error?.status === 400 ||
+      error?.message === 'No access token cookie found.'
+    )
+      return;
 
     setShow(true);
     setTimeout(() => {
@@ -32,7 +38,7 @@ export default function ErrorProvider({ children }: Props): JSX.Element {
     <SetErrorContext.Provider value={useMemo(() => setError, [setError])}>
       <ErrorContext.Provider value={useMemo(() => error, [error])}>
         <AnimatePresence>
-          {error && (
+          {show && (
             <ErrorToast
               message={error?.message}
               status={error?.status}


### PR DESCRIPTION
This PR follows the latest breaking changes from otr-api PR listed below, adjusting the new values for the rating graph and removing the Teammate and Opponent cards.

Added minor changes to this PR too:
- Fixed error toast being blank
- Fixed negative rating number showing a double `-`

This PR needs the following otr-api PR to be merged:
- [x] https://github.com/osu-tournament-rating/otr-api/pull/75

@hburn7 please review after pushing your PR

closes #75 