### PR TITLE
Refactor 'roles' to 'scopes'

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -31,7 +31,7 @@ export async function getSession(onlyData: boolean = false) {
       osuPlayMode: session?.osuPlayMode,
       osuPlayModeSelected: session?.osuPlayModeSelected,
       username: session?.username,
-      roles: session?.roles,
+      scopes: session?.scopes,
       accessToken: session?.accessToken,
     };
 
@@ -81,7 +81,7 @@ export async function login(cookie: {
   session.osuPlayMode = loggedUser.osuPlayMode;
   session.osuPlayModeSelected = loggedUser.osuPlayMode;
   session.username = loggedUser.username;
-  session.roles = loggedUser.roles;
+  session.scopes = loggedUser.scopes;
   session.isLogged = true;
 
   await session.save();

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -10,12 +10,12 @@ export const metadata: Metadata = {
 };
 
 export default async function page() {
-  const { roles } = await getSession(true);
+  const { scopes } = await getSession(true);
 
   return (
     <main className={styles.pageContainer}>
       <Guidelines />
-      <MatchForm userRoles={roles} />
+      <MatchForm userScopes={scopes} />
     </main>
   );
 }

--- a/components/SubmitMatches/MatchForm/MatchForm.tsx
+++ b/components/SubmitMatches/MatchForm/MatchForm.tsx
@@ -23,7 +23,7 @@ function SubmitButton() {
   );
 }
 
-export default function MatchForm({ userRoles }: { userRoles: Array<string> }) {
+export default function MatchForm({ userScopes }: { userScopes: Array<string> }) {
   const [state, formAction] = useFormState(saveTournamentMatches, initialState);
 
   const [rulesAccepted, setRulesAccepted] = useState(false);
@@ -249,7 +249,7 @@ export default function MatchForm({ userRoles }: { userRoles: Array<string> }) {
                   matches can lead to a restriction
                 </span>
               </div>
-              {(userRoles.includes('verifier')) && (
+              {(userScopes.includes('verifier')) && (
                 <div className={clsx(styles.row, styles.checkbox)}>
                   <input
                     type="checkbox"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,7 +66,7 @@ export interface SessionUser {
   osuPlayMode?: number;
   osuPlayModeSelected?: number;
   username?: string;
-  roles?: [string];
+  scopes?: [string];
   accessToken?: string;
   refreshToken?: string;
   isLogged: boolean;


### PR DESCRIPTION
Addresses changes in https://github.com/osu-tournament-rating/otr-api/pull/213

The structure of data returned from `/me` has changed, this PR addresses the new schema. It also refactors the `roles` naming to `scopes` which is used in the API.

Cookies must be cleared, otherwise the new changes will not be recorded in the user's session.