### PR TITLE
fix leaderboard params when changing page

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -550,7 +550,9 @@ export async function paginationParamsToURL(params: {}) {
         let string = `${index !== 0 ? '&' : ''}${key}=`;
 
         params[key].forEach((value, index) => {
-          string += `${value}${index === 0 ? `&${key}=` : ''}`;
+          string += `${value}${
+            index < params[key].length - 1 ? `&${key}=` : ''
+          }`;
         });
 
         return (url += `${string}`);


### PR DESCRIPTION
Fixed URL creation when more than 2 tier filters were selected while changing page