### PR TITLE
create gamemode cookie on login

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -84,6 +84,14 @@ export async function login(cookie: {
   session.scopes = loggedUser.scopes;
   session.isLogged = true;
 
+  await cookies().set('OTR-user-selected-osu-mode', loggedUser.osuPlayMode, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 1209600,
+  });
+
   await session.save();
 
   /* await changeOsuModeCookie(res.osuPlayMode); */

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -31,6 +31,7 @@ export default async function page({
 
   if (!data.generalStats || !data.playerInfo) {
     throw Error('4');
+    return;
   }
 
   return (


### PR DESCRIPTION
Fixed dashboard error not showing the correct message and now on login the gamemode cookie will be created with the user preferred gamemode.