### PR TITLE
Change rating display/filter to use round/ceil instead of floor

### DIFF
--- a/components/Collapsible/FiltersCollapsible/FiltersCollapsible.tsx
+++ b/components/Collapsible/FiltersCollapsible/FiltersCollapsible.tsx
@@ -132,7 +132,7 @@ export default function FiltersCollapsible({
               <RangeSlider
                 name={'rating'}
                 min={100}
-                max={Math.floor(data.maxRating)}
+                max={Math.ceil(data.maxRating)}
                 value={rating}
                 setParamsToPush={setParamsToPush}
               />

--- a/components/Leaderboard/Leaderboard.tsx
+++ b/components/Leaderboard/Leaderboard.tsx
@@ -89,7 +89,7 @@ export default function Leaderboard({
                     />
                   </div>
                 </td>
-                <td>{Math.floor(player.rating)}</td>
+                <td>{Math.round(player.rating)}</td>
                 <td>{player.matchesPlayed}</td>
                 <td>{(player.winRate * 100).toFixed(1)}%</td>
               </tr>


### PR DESCRIPTION
Using `ceil` for the filter max rating ensures that all players will be included when using that value for a range, and using `round` for the leaderboard keeps it consistent with ratings displayed on profiles.

Closes osu-tournament-rating/otr-api#237