### PR TITLE
Recent tournament performances

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -171,12 +171,12 @@ export default async function page({
                 }
               />
             </GridCard>
-            <GridCard title={'Worst tournament performances'}>
-              {data?.tournamentStats.worstPerformances.length > 0 ? (
+            <GridCard title={'Recent tournament performances'}>
+              {data?.tournamentStats.recentPerformances.length > 0 ? (
                 <BarChart
                   mainAxe={'y'}
-                  worstTournamentPerformances={
-                    data?.tournamentStats.worstPerformances
+                  recentTournamentPerformances={
+                    data?.tournamentStats.recentPerformances
                   }
                 />
               ) : (

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -177,12 +177,12 @@ export default async function page({
                 }
               />
             </GridCard>
-            <GridCard title={'Worst tournament performances'}>
-              {data?.tournamentStats.worstPerformances.length > 0 ? (
+            <GridCard title={'Recent tournament performances'}>
+              {data?.tournamentStats.recentPerformances.length > 0 ? (
                 <BarChart
                   mainAxe={'y'}
-                  worstTournamentPerformances={
-                    data?.tournamentStats.worstPerformances
+                  recentTournamentPerformances={
+                    data?.tournamentStats.recentPerformances
                   }
                 />
               ) : (

--- a/components/Charts/BarChart/BarChart.tsx
+++ b/components/Charts/BarChart/BarChart.tsx
@@ -25,12 +25,12 @@ ChartJS.register(
 export default function BarChart({
   mainAxe = 'x',
   bestTournamentPerformances,
-  worstTournamentPerformances,
+  recentTournamentPerformances,
   teamSizes,
 }: {
   mainAxe: any;
   bestTournamentPerformances?: any;
-  worstTournamentPerformances?: any;
+  recentTournamentPerformances?: any;
   teamSizes?: any;
 }) {
   const [font, setFont] = useState('');
@@ -58,17 +58,15 @@ export default function BarChart({
       dataScores[index] = tournament.matchCost.toFixed(2);
       return;
     });
-    dataScores.sort((a, b) => b - a);
   }
 
-  if (worstTournamentPerformances) {
+  if (recentTournamentPerformances) {
     labels.length = 0;
-    worstTournamentPerformances.map((tournament: any, index: any) => {
+    recentTournamentPerformances.map((tournament: any, index: any) => {
       labels[index] = tournament.tournamentName;
       dataScores[index] = tournament.matchCost.toFixed(2);
       return;
     });
-    dataScores.sort((a, b) => b - a);
   }
 
   if (teamSizes) {
@@ -116,11 +114,11 @@ export default function BarChart({
         },
         grace: '2%',
         min:
-          bestTournamentPerformances || worstTournamentPerformances
+          bestTournamentPerformances || recentTournamentPerformances
             ? 0.5
             : null,
         max:
-          bestTournamentPerformances || worstTournamentPerformances
+          bestTournamentPerformances || recentTournamentPerformances
             ? +dataScores[0]
             : null,
         suggestedMax: 2,


### PR DESCRIPTION
- Add recent tournament performances (changes from https://github.com/osu-tournament-rating/otr-api/pull/321).
- Removes sorting of recent/best performances bar charts (there is a bug, the values would not align with the labels). The API handles the sorting anyway so it wasn't noticed until now.