### PR TITLE
Submission form split mania to 4k and 7k

### DIFF
--- a/components/SubmitMatches/MatchForm/MatchForm.tsx
+++ b/components/SubmitMatches/MatchForm/MatchForm.tsx
@@ -84,8 +84,8 @@ export default function MatchForm({
                     <option value={0}>osu!</option>
                     <option value={1}>osu!taiko</option>
                     <option value={2}>osu!catch</option>
-                    <option value={3}>osu!mania4k</option>
-                    <option value={4}>osu!mania7k</option>
+                    <option value={3}>osu!mania 4K</option>
+                    <option value={4}>osu!mania 7K</option>
                   </select>
                 </div>
               </div>

--- a/components/SubmitMatches/MatchForm/MatchForm.tsx
+++ b/components/SubmitMatches/MatchForm/MatchForm.tsx
@@ -86,7 +86,7 @@ export default function MatchForm({
                     <option value={2}>osu!catch</option>
                     <option value={4}>osu!mania 4K</option>
                     <option value={5}>osu!mania 7K</option>
-                    <option value={3}>osu!mania &lpar;Other&rpar;</option>
+                    <option value={3}>osu!mania (Other)</option>
                   </select>
                 </div>
               </div>

--- a/components/SubmitMatches/MatchForm/MatchForm.tsx
+++ b/components/SubmitMatches/MatchForm/MatchForm.tsx
@@ -81,10 +81,11 @@ export default function MatchForm({
                     {state?.errors?.mode}
                   </span>
                   <select name="gameMode" id={styles.gamemode} required={true}>
-                    <option value={0}>osu!Standard</option>
-                    <option value={1}>osu!Taiko</option>
-                    <option value={2}>osu!Catch</option>
-                    <option value={3}>osu!Mania</option>
+                    <option value={0}>osu!</option>
+                    <option value={1}>osu!taiko</option>
+                    <option value={2}>osu!catch</option>
+                    <option value={3}>osu!mania4k</option>
+                    <option value={4}>osu!mania7k</option>
                   </select>
                 </div>
               </div>

--- a/components/SubmitMatches/MatchForm/MatchForm.tsx
+++ b/components/SubmitMatches/MatchForm/MatchForm.tsx
@@ -84,8 +84,9 @@ export default function MatchForm({
                     <option value={0}>osu!</option>
                     <option value={1}>osu!taiko</option>
                     <option value={2}>osu!catch</option>
-                    <option value={3}>osu!mania 4K</option>
-                    <option value={4}>osu!mania 7K</option>
+                    <option value={4}>osu!mania 4K</option>
+                    <option value={5}>osu!mania 7K</option>
+                    <option value={3}>osu!mania &lpar;Other&rpar;</option>
                   </select>
                 </div>
               </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,7 +43,7 @@ export const MatchesSubmitFormSchema = z.object({
   ]),
   rankRangeLowerBound: z.number().min(1),
   teamSize: z.number().min(1).max(8),
-  mode: z.number().min(0).max(3),
+  mode: z.number().min(0).max(5),
   submitterId: z.number().positive(),
   ids: z
     .array(


### PR DESCRIPTION
Removed `osu!mania` from the submission form and replaced by:
- [x] `osu!mania 4K` with code `3`
- [x] `osu!mania 7K` with code `4`

**This can't be merged until the following PR is done and merged:**
- https://github.com/osu-tournament-rating/otr-api/issues/333

closes #195 