### PR TITLE
Introduce partial typing for player statistics fetching

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -7,7 +7,7 @@ import {
   TournamentsQuerySchema,
   UserpageQuerySchema,
 } from '@/lib/types';
-import { MatchesWrapper, TournamentsWrapper } from '@osu-tournament-rating/otr-api-client';
+import { MatchesWrapper, PlayersWrapper, TournamentsWrapper, Ruleset } from '@osu-tournament-rating/otr-api-client';
 import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 
@@ -330,57 +330,29 @@ export async function fetchUserPageTitle(player: string | number) {
   return null;
 }
 
-export async function fetchUserPage(player: string | number, params) {
-  const session = await getSessionData();
-
+export async function fetchPlayerStats(player: string | number, params) {
   const osuMode =
-    (await cookies().get('OTR-user-selected-osu-mode')?.value) ?? '0';
-
-  let urlStringObject = {
-    ruleset: osuMode,
-  };
-
-  if (session?.playerId) {
-    urlStringObject.comparerId = session?.playerId;
-  }
+    (await cookies().get('OTR-user-selected-osu-mode')?.value as Ruleset | undefined) ?? Ruleset.Osu;
 
   const queryCheck = await UserpageQuerySchema.safeParse({
     time: params?.time,
   });
 
-  // put time on the url only if the value is not undefined and without errors
+  const wrapper = new PlayersWrapper(apiWrapperConfiguration);
+
+  let minDate = undefined;
   if (queryCheck.success && queryCheck.data.time) {
-    let minDate = new Date();
+    minDate = new Date();
     minDate.setDate(minDate.getDate() - params?.time);
-    let year = minDate.getFullYear();
-    let month = String(minDate.getMonth() + 1).padStart(2, '0');
-    let day = String(minDate.getDate()).padStart(2, '0');
-    minDate = `${year}-${month}-${day}`;
-
-    urlStringObject.dateMin = minDate;
   }
 
-  const urlParams = decodeURIComponent(
-    new URLSearchParams(urlStringObject).toString()
-  );
+  const statsResponse = await wrapper.getStats({ key: player as string, ruleset: osuMode, dateMin: minDate });
 
-  let res = await fetch(
-    `${process.env.REACT_APP_API_URL}/players/${player}/stats?${urlParams}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session?.accessToken}`,
-      },
-    }
-  );
-
-  if (!res?.ok) {
-    return res?.status === 404 ? notFound() : redirect('/');
+  if (statsResponse.status != 200) {
+    return statsResponse.status === 404 ? notFound() : redirect('/');
   }
 
-  res = await res.json();
-
-  return res;
+  return statsResponse.result;
 }
 
 export async function paginationParamsToURL(params: {}) {

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -365,7 +365,7 @@ export async function fetchUserPage(player: string | number, params) {
   );
 
   let res = await fetch(
-    `${process.env.REACT_APP_API_URL}/stats/${player}?${urlParams}`,
+    `${process.env.REACT_APP_API_URL}/players/${player}/stats?${urlParams}`,
     {
       headers: {
         'Content-Type': 'application/json',

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -330,31 +330,6 @@ export async function fetchUserPageTitle(player: string | number) {
   return null;
 }
 
-export async function fetchPlayerStats(player: string | number, params) {
-  const osuMode =
-    (await cookies().get('OTR-user-selected-osu-mode')?.value as Ruleset | undefined) ?? Ruleset.Osu;
-
-  const queryCheck = await UserpageQuerySchema.safeParse({
-    time: params?.time,
-  });
-
-  const wrapper = new PlayersWrapper(apiWrapperConfiguration);
-
-  let minDate = undefined;
-  if (queryCheck.success && queryCheck.data.time) {
-    minDate = new Date();
-    minDate.setDate(minDate.getDate() - params?.time);
-  }
-
-  const statsResponse = await wrapper.getStats({ key: player as string, ruleset: osuMode, dateMin: minDate });
-
-  if (statsResponse.status != 200) {
-    return statsResponse.status === 404 ? notFound() : redirect('/');
-  }
-
-  return statsResponse.result;
-}
-
 export async function paginationParamsToURL(params: {}) {
   let url = '';
 

--- a/app/actions/players.ts
+++ b/app/actions/players.ts
@@ -1,0 +1,30 @@
+import { apiWrapperConfiguration } from "@/lib/auth";
+import { UserpageQuerySchema } from "@/lib/types";
+import { PlayersWrapper, Ruleset } from "@osu-tournament-rating/otr-api-client";
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+
+export async function fetchPlayerStats(player: string | number, params) {
+    const osuMode =
+      (await cookies().get('OTR-user-selected-osu-mode')?.value as Ruleset | undefined) ?? Ruleset.Osu;
+  
+    const queryCheck = await UserpageQuerySchema.safeParse({
+      time: params?.time,
+    });
+  
+    const wrapper = new PlayersWrapper(apiWrapperConfiguration);
+  
+    let minDate = undefined;
+    if (queryCheck.success && queryCheck.data.time) {
+      minDate = new Date();
+      minDate.setDate(minDate.getDate() - params?.time);
+    }
+  
+    const statsResponse = await wrapper.getStats({ key: player as string, ruleset: osuMode, dateMin: minDate });
+  
+    if (statsResponse.status != 200) {
+      return statsResponse.status === 404 ? notFound() : redirect('/');
+    }
+  
+    return statsResponse.result;
+  }

--- a/app/players/[id]/page.tsx
+++ b/app/players/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchUserPage, fetchUserPageTitle } from '@/app/actions';
+import { fetchPlayerStats, fetchUserPageTitle } from '@/app/actions';
 import AreaChart from '@/components/Charts/AreaChart/AreaChart';
 import BarChart from '@/components/Charts/BarChart/BarChart';
 import DoughnutChart from '@/components/Charts/DoughnutChart/DoughnutChart';
@@ -36,7 +36,7 @@ export default async function page({
   searchParams: URLSearchParams;
   params: { id: string | number };
 }) {
-  const data = await fetchUserPage(id, searchParams);
+  const data = await fetchPlayerStats(id, searchParams);
 
   return (
     <main className={styles.main}>
@@ -45,8 +45,8 @@ export default async function page({
         <FilterButtons params={searchParams} />
         <div className={styles.graphContainer}>
           {data?.baseStats &&
-          data?.matchStats &&
-          data?.matchStats.gamesPlayed > 0 ? (
+            data?.matchStats &&
+            data?.matchStats.gamesPlayed > 0 ? (
             <>
               <div className={styles.header}>
                 <div className={styles.rating}>

--- a/app/players/[id]/page.tsx
+++ b/app/players/[id]/page.tsx
@@ -1,8 +1,7 @@
-import { fetchPlayerStats, fetchUserPageTitle } from '@/app/actions';
+import { fetchUserPageTitle } from '@/app/actions';
 import AreaChart from '@/components/Charts/AreaChart/AreaChart';
 import BarChart from '@/components/Charts/BarChart/BarChart';
 import DoughnutChart from '@/components/Charts/DoughnutChart/DoughnutChart';
-import MiddleBarChart from '@/components/Charts/MiddleBarChart/MiddleBarChart';
 import PlayersBarChart from '@/components/Charts/PlayersBarChart/PlayersBarChart';
 import RadarChart from '@/components/Charts/RadarChart/RadarChart';
 import FilterButtons from '@/components/Dashboard/FilterButtons/FilterButtons';
@@ -14,6 +13,7 @@ import FormattedNumber from '@/components/FormattedNumber/FormattedNumber';
 import UserMainCard from '@/components/Profile/UserMainCard/UserMainCard';
 import clsx from 'clsx';
 import styles from './page.module.css';
+import { fetchPlayerStats } from '@/app/actions/players';
 
 export async function generateMetadata({
   params: { id },


### PR DESCRIPTION
Attempts to partially introduce typing for the `AreaChart` type (which is responsible for displaying the line chart on player profiles). I was getting stuck on some of the anonymous types but at least things are a *little* better now.

Also:

- Renames some variables to make more sense
- Attempts to clean up some of the old code in general