### PR TITLE
Fix newlines in match warning tooltip

### DIFF
--- a/components/badges/WarningFlagsBadge.tsx
+++ b/components/badges/WarningFlagsBadge.tsx
@@ -26,9 +26,9 @@ export default function WarningFlagsBadge({
   return (
     <Tooltip>
       <TooltipContent>
-        <ul>
+        <ul className="list-disc pl-3">
           {metadata.map(({ text }, index) => (
-              <li key={index}>• {text}</li>
+              <li key={index}>{text}</li>
           ))}
         </ul>
       </TooltipContent>

--- a/components/badges/WarningFlagsBadge.tsx
+++ b/components/badges/WarningFlagsBadge.tsx
@@ -4,7 +4,7 @@ import {
 } from '@/lib/enums';
 import { ApiItemType } from '@/lib/types';
 import { TriangleAlertIcon } from 'lucide-react';
-import SimpleTooltip from '../simple-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { Badge } from '../ui/badge';
 
 export default function WarningFlagsBadge({
@@ -23,16 +23,20 @@ export default function WarningFlagsBadge({
       ? MatchWarningFlagsEnumHelper.getMetadata(value)
       : GameWarningFlagsEnumHelper.getMetadata(value);
 
-  let tooltipText = '';
-  metadata.map(({ text }) => {
-    tooltipText += `• ${text}\n`;
-  });
-
   return (
-    <SimpleTooltip content={tooltipText}>
-      <Badge className="text-warning" variant={'outline'}>
-        <TriangleAlertIcon />
-      </Badge>
-    </SimpleTooltip>
+    <Tooltip>
+      <TooltipContent>
+        <ul>
+          {metadata.map(({ text }, index) => (
+              <li key={index}>• {text}</li>
+          ))}
+        </ul>
+      </TooltipContent>
+      <TooltipTrigger>
+        <Badge className="text-warning" variant={'outline'}>
+          <TriangleAlertIcon />
+        </Badge>
+      </TooltipTrigger>
+    </Tooltip>
   );
 }

--- a/components/badges/WarningFlagsBadge.tsx
+++ b/components/badges/WarningFlagsBadge.tsx
@@ -26,11 +26,14 @@ export default function WarningFlagsBadge({
   return (
     <Tooltip>
       <TooltipContent>
-        <ul className="list-disc pl-3">
-          {metadata.map(({ text }, index) => (
-              <li key={index}>{text}</li>
-          ))}
-        </ul>
+        <div>
+          <strong>Warnings:</strong>
+          <ul className="list-disc pl-3.5 mt-1">
+            {metadata.map(({ text }, index) => (
+                <li key={index}>{text}</li>
+            ))}
+          </ul>
+        </div>
       </TooltipContent>
       <TooltipTrigger>
         <Badge className="text-warning" variant={'outline'}>


### PR DESCRIPTION
Use `Tooltip` and `ul` to display multiple match warning flags on different lines

![image](https://github.com/user-attachments/assets/1a0d7a92-e728-49aa-bf99-02608364a4f6)
