### PR TITLE
Center global rank and player username on the leaderboard vertically

### DIFF
--- a/app/leaderboard/columns.tsx
+++ b/app/leaderboard/columns.tsx
@@ -13,7 +13,7 @@ export const columns = [
   columnHelper.accessor('globalRank', {
     header: 'Rank',
     cell: ({ getValue, row }) => (
-      <div className="flex flex-row justify-between">
+      <div className="flex flex-row items-center justify-between">
         <p className="font-sans">#{getValue()}</p>
         <div className="flex">
           <Image
@@ -33,7 +33,7 @@ export const columns = [
   columnHelper.accessor('player.osuId', {
     header: 'Player',
     cell: ({ getValue, row }) => (
-      <div className="flex flex-row gap-2 font-sans">
+      <div className="flex flex-row items-center gap-2 font-sans">
         <Image
           src={`https://a.ppy.sh/${getValue()}`}
           alt="avatar"


### PR DESCRIPTION
Aligns it better with the rest of the text in each row

old:
![image](https://github.com/user-attachments/assets/81f0a4a0-af5a-45c7-b22f-dcd941adb9a4)


new:
![image](https://github.com/user-attachments/assets/757e5c4c-364f-49a6-b9e1-891b442fa522)
