### PR TITLE
Keep user values on filter reset

### DIFF
--- a/components/leaderboard/LeaderboardFilter.tsx
+++ b/components/leaderboard/LeaderboardFilter.tsx
@@ -52,6 +52,9 @@ export default function LeaderboardFilter({
     resolver: zodResolver(leaderboardFilterSchema),
     values: filter,
     defaultValues: defaultLeaderboardFilterValues,
+    resetOptions: {
+      keepDirtyValues: true
+    }
   });
 
   const router = useRouter();


### PR DESCRIPTION
This fixes an issue where the leaderboard filter would not update correctly visually when ruleset was changed back to 0 (by clicking on the osu!standard icon). 

Root cause was a form reset that occurs when the filter values are done calculating:
https://react-hook-form.com/docs/useform#resetOptions