### PR TITLE
Rearrange boolean expression for submit button checks

### DIFF
--- a/components/admin-notes/AdminNoteForm.tsx
+++ b/components/admin-notes/AdminNoteForm.tsx
@@ -68,8 +68,7 @@ export default function AdminNoteForm() {
           <Button
             type="submit"
             disabled={
-              !form.formState.isDirty ||
-              (form.formState.isDirty && !form.formState.isValid)
+              !form.formState.isValid || !form.formState.isDirty
             }
           >
             {form.formState.isSubmitting ? (

--- a/components/games/GameAdminView.tsx
+++ b/components/games/GameAdminView.tsx
@@ -298,8 +298,7 @@ export default function GameAdminView({ game }: { game: GameDTO }) {
               <Button
                 type="submit"
                 disabled={
-                  !form.formState.isDirty ||
-                  (form.formState.isDirty && !form.formState.isValid)
+                  !form.formState.isValid || !form.formState.isDirty
                 }
               >
                 {form.formState.isSubmitting ? (

--- a/components/matches/MatchAdminView.tsx
+++ b/components/matches/MatchAdminView.tsx
@@ -214,8 +214,7 @@ export default function MatchAdminView({ match }: { match: MatchCompactDTO }) {
               <Button
                 type="submit"
                 disabled={
-                  !form.formState.isDirty ||
-                  (form.formState.isDirty && !form.formState.isValid)
+                  !form.formState.isValid || !form.formState.isDirty
                 }
               >
                 {form.formState.isSubmitting ? (

--- a/components/tournaments/TournamentAdminView.tsx
+++ b/components/tournaments/TournamentAdminView.tsx
@@ -274,8 +274,7 @@ export default function TournamentAdminView({
               <Button
                 type="submit"
                 disabled={
-                  !form.formState.isDirty ||
-                  (form.formState.isDirty && !form.formState.isValid)
+                  !form.formState.isValid || !form.formState.isDirty
                 }
               >
                 {form.formState.isSubmitting ? (


### PR DESCRIPTION
This change rearranges all instances of 
```
!form.formState.isDirty ||
(form.formState.isDirty && !form.formState.isValid)
```
to
```
!form.formState.isValid || !form.formState.isDirty
```

This helps simplify the expression, but also ensures that `isValid` is correctly calculated each time the "Save" buttons are being rendered by putting it as the first term in the expression.

This fixes the issue where the "Save" button would not properly enable itself when a form value was changed for the first time.