### PR TITLE
Fix stale state after entity edits

### DIFF
--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -134,7 +134,7 @@ function TournamentHeader({ tournament }: { tournament: TournamentDTO }) {
         </h1>
 
         {/* Tournament metadata */}
-        <div className="flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+        <div className="flex flex-col gap-2 bg-popover text-sm text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
           <div className="flex items-center gap-1.5">
             <RulesetIcon
               ruleset={tournament.ruleset}

--- a/components/admin-notes/AdminNoteListItem.tsx
+++ b/components/admin-notes/AdminNoteListItem.tsx
@@ -25,6 +25,7 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import { AlertDialogTrigger } from '@radix-ui/react-alert-dialog';
 import { useSession } from '@/lib/hooks/useSession';
+import { useRouter } from 'next/navigation';
 
 export default function AdminNoteListItem({
   note,
@@ -34,6 +35,7 @@ export default function AdminNoteListItem({
   entity: AdminNoteRouteTarget;
 }) {
   const session = useSession();
+  const router = useRouter();
 
   // Restrict edit/delete functionality to the user who created the note
   const showModificationButtons =
@@ -48,6 +50,7 @@ export default function AdminNoteListItem({
         entity,
       });
       toast.success('Note deleted successfully');
+      router.refresh();
     } catch {
       toast.error('Failed to delete note');
     }
@@ -61,6 +64,7 @@ export default function AdminNoteListItem({
         body: editedNote,
       });
       toast.success('Note updated successfully');
+      router.refresh();
     } catch {
       toast.error('Failed to update note');
     }

--- a/components/admin-notes/AdminNoteView.tsx
+++ b/components/admin-notes/AdminNoteView.tsx
@@ -7,6 +7,7 @@ import {
 } from '@osu-tournament-rating/otr-api-client';
 import { Loader2, StickyNote } from 'lucide-react';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Button } from '../ui/button';
 import {
   Dialog,
@@ -63,6 +64,7 @@ export default function AdminNoteView({
   entityDisplayName,
 }: AdminNoteViewProps) {
   const session = useSession();
+  const router = useRouter();
 
   const form = useForm<z.infer<typeof adminNoteFormSchema>>({
     resolver: zodResolver(adminNoteFormSchema),
@@ -89,7 +91,9 @@ export default function AdminNoteView({
         body: data.note,
       });
 
+      form.reset();
       toast.success(`Created admin note for ${entityDisplayName}`);
+      router.refresh();
     } catch {
       toast.error(`Failed to create admin note for ${entityDisplayName}`);
     }

--- a/components/games/GameAdminView.tsx
+++ b/components/games/GameAdminView.tsx
@@ -46,6 +46,7 @@ import { update } from '@/lib/actions/games';
 import { createPatchOperations } from '@/lib/utils/form';
 import { errorSaveToast, saveToast } from '@/lib/utils/toasts';
 import DeleteButton from '../shared/DeleteButton';
+import { useRouter } from 'next/navigation';
 
 const inputChangedStyle = (fieldState: ControllerFieldState) =>
   cn(
@@ -76,6 +77,8 @@ export default function GameAdminView({ game }: { game: GameDTO }) {
   });
 
   const session = useSession();
+  const router = useRouter();
+
   if (!session?.scopes?.includes(Roles.Admin)) {
     return null;
   }
@@ -89,6 +92,7 @@ export default function GameAdminView({ game }: { game: GameDTO }) {
 
       form.reset(patchedGame);
       saveToast();
+      router.refresh();
     } catch {
       errorSaveToast();
     }

--- a/components/matches/MatchAdminView.tsx
+++ b/components/matches/MatchAdminView.tsx
@@ -43,6 +43,7 @@ import VerificationStatusSelectContent from '../select/VerificationStatusSelectC
 import { errorSaveToast, saveToast } from '@/lib/utils/toasts';
 import { useSession } from '@/lib/hooks/useSession';
 import DeleteButton from '../shared/DeleteButton';
+import { useRouter } from 'next/navigation';
 
 const inputChangedStyle = (fieldState: ControllerFieldState) =>
   cn(
@@ -66,6 +67,8 @@ export default function MatchAdminView({ match }: { match: MatchCompactDTO }) {
   });
 
   const session = useSession();
+  const router = useRouter();
+
   if (!session?.scopes?.includes(Roles.Admin)) {
     return null;
   }
@@ -79,6 +82,7 @@ export default function MatchAdminView({ match }: { match: MatchCompactDTO }) {
 
       form.reset(patchedMatch);
       saveToast();
+      router.refresh();
     } catch {
       errorSaveToast();
     }

--- a/components/scores/ScoreAdminView.tsx
+++ b/components/scores/ScoreAdminView.tsx
@@ -61,6 +61,7 @@ import { Textarea } from '../ui/textarea';
 import { toast } from 'sonner';
 import AdminNotesList from '../admin-notes/AdminNoteList';
 import DeleteButton from '../shared/DeleteButton';
+import { useRouter } from 'next/navigation';
 
 const inputChangedStyle = (fieldState: ControllerFieldState) =>
   cn(
@@ -90,6 +91,8 @@ export default function ScoreAdminView({ score }: { score: GameScoreDTO }) {
     typeof scoreEditFormSchema
   > | null>(null);
 
+  const router = useRouter();
+
   if (!session?.scopes?.includes(Roles.Admin)) {
     return null;
   }
@@ -116,6 +119,8 @@ export default function ScoreAdminView({ score }: { score: GameScoreDTO }) {
       // Reset forms
       form.reset(patchedScore);
       setAdminNote('');
+
+      router.refresh();
     } catch {
       errorSaveToast();
     } finally {

--- a/components/tournaments/TournamentAdminView.tsx
+++ b/components/tournaments/TournamentAdminView.tsx
@@ -14,6 +14,7 @@ import {
 import { EditIcon, Loader2 } from 'lucide-react';
 import { ControllerFieldState, useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useRouter } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -59,6 +60,7 @@ export default function TournamentAdminView({
   tournament,
 }: TournamentAdminViewProps) {
   const session = useSession();
+  const router = useRouter();
   const form = useForm<z.infer<typeof tournamentEditFormSchema>>({
     resolver: zodResolver(tournamentEditFormSchema),
     defaultValues: tournament,
@@ -79,6 +81,7 @@ export default function TournamentAdminView({
       });
       form.reset(patchedTournament);
       saveToast();
+      router.refresh();
     } catch {
       errorSaveToast();
     }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40',
         outline:
-          'border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-popover shadow-xs hover:bg-accent hover:text-accent-foreground',
         secondary:
           'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
         ghost: 'hover:bg-none hover:text-accent-foreground',


### PR DESCRIPTION
When editing entities, the state wouldn't update without a hard refresh.