### PR TITLE
Remove submit behavior from tournament filter buttons

### DIFF
--- a/components/tournaments/list/TournamentListFilter.tsx
+++ b/components/tournaments/list/TournamentListFilter.tsx
@@ -180,6 +180,7 @@ const RulesetFilter = ({ control }: { control: Control<FilterFormData> }) => {
                 return (
                   <Button
                     key={`ruleset-${ruleset}`}
+                    type="button"
                     variant={isSelected ? 'default' : 'outline'}
                     onClick={() =>
                       field.onChange(isSelected ? undefined : rulesetNumber)
@@ -240,6 +241,7 @@ const SortControls = ({ control }: { control: Control<FilterFormData> }) => (
               <TooltipTrigger asChild>
                 <FormControl>
                   <Button
+                    type="button"
                     variant="outline"
                     size="icon"
                     onClick={() => field.onChange(!field.value)}


### PR DESCRIPTION
Closes #379 

Adding `type="button"` overrides the default behavior for form buttons, which is to submit the form and refresh the page.

This resolves a bug where the page would refresh upon clicking on a tournament ruleset filter or the ascending/descending button, removing the filter.
