### PR TITLE
Fix missing leaderboard tooltips

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import './globals.css';
 import Footer from '@/components/footer/Footer';
 import SessionProvider from '@/components/session-provider';
 import { getSession } from '@/lib/api/server';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -40,14 +41,16 @@ export default async function RootLayout({
         className={`font-sans ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ThemeProvider attribute="class" disableTransitionOnChange>
-          <SessionProvider user={session}>
-            <Header />
-            <main className="mx-auto w-full sm:px-5 md:max-w-4xl xl:max-w-6xl">
-              {children}
-            </main>
-            <Footer />
-            <Toaster richColors />
-          </SessionProvider>
+          <TooltipProvider>
+            <SessionProvider user={session}>
+              <Header />
+              <main className="mx-auto w-full sm:px-5 md:max-w-4xl xl:max-w-6xl">
+                {children}
+              </main>
+              <Footer />
+              <Toaster richColors />
+            </SessionProvider>
+          </TooltipProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/leaderboard/columns.tsx
+++ b/app/leaderboard/columns.tsx
@@ -99,7 +99,7 @@ export const columns = [
       const subTier = row.original.tierProgress.currentSubTier;
 
       return (
-        <div className="flex justify-center rounded-lg bg-muted/20 p-1">
+        <div className="flex justify-center rounded-lg">
           <SimpleTooltip content={getTierString(tier, subTier)}>
             {/* We actually have to use a div here, else we encounter a 'Maximum update depth exceeded' error */}
             <div>

--- a/app/leaderboard/data-table.tsx
+++ b/app/leaderboard/data-table.tsx
@@ -32,20 +32,16 @@ export function LeaderboardDataTable<TData, TValue>({
   });
 
   const getRowClassName = (index: number) => {
-    const baseClasses = 'transition-colors duration-200 hover:bg-muted/30';
     // Simple alternating row colors for all ranks
-    return `${baseClasses} ${index % 2 === 0 ? 'bg-background/50' : 'bg-muted/10'}`;
+    return `${index % 2 === 0 ? 'bg-background/50' : 'bg-muted/10'}`;
   };
 
   return (
-    <div className="overflow-x-auto rounded-lg border bg-gradient-to-br from-background to-muted/20">
+    <div className="overflow-x-auto rounded-lg border">
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow
-              key={headerGroup.id}
-              className="bg-muted/50 hover:bg-muted/70"
-            >
+            <TableRow key={headerGroup.id} className="bg-muted/50">
               {headerGroup.headers.map((header) => {
                 return (
                   <TableHead

--- a/components/dates/FormattedDate.tsx
+++ b/components/dates/FormattedDate.tsx
@@ -65,19 +65,17 @@ export default function FormattedDate({
 
   return (
     <ClientOnly>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className={className}>{dateString}</span>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p className="flex gap-1">
-              <span>{fullDay}</span>
-              <span className="text-primary">{fullTime}</span>
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={className}>{dateString}</span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="flex gap-1">
+            <span>{fullDay}</span>
+            <span className="text-primary">{fullTime}</span>
+          </p>
+        </TooltipContent>
+      </Tooltip>
     </ClientOnly>
   );
 }

--- a/components/icons/TierIcon.tsx
+++ b/components/icons/TierIcon.tsx
@@ -44,7 +44,7 @@ export default function TierIcon({
     return <Icon />;
   }
 
-  const tooltipContent = getTierString(tier, tooltip ? subTier : undefined);
+  const tooltipContent = getTierString(tier, subTier);
 
   // Here purely for convenience
   if (tier === 'Elite Grandmaster') {

--- a/components/shared/DeleteButton.tsx
+++ b/components/shared/DeleteButton.tsx
@@ -75,63 +75,59 @@ export default function DeleteButton({
   };
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <Dialog open={isOpen} onOpenChange={setIsOpen}>
-          <TooltipTrigger asChild>
-            <DialogTrigger asChild>
-              <Button variant="destructive" size="sm">
-                <Trash2 className="size-4" />
-              </Button>
-            </DialogTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Delete {entityLabels[entityType]}</p>
-          </TooltipContent>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                Confirm Delete {entityLabels[entityType]}
-              </DialogTitle>
-              <DialogDescription asChild>
-                <div>
-                  Are you sure you want to delete <strong>{entityName}</strong>?
-                  This action cannot be undone.
-                  <br />
-                  <br />
-                  <ul className="list-disc pl-4">
-                    <li>This action will cascade to all children.</li>
-                    <li>All associated data will be permanently removed.</li>
-                  </ul>
-                </div>
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={handleCancel}
-                disabled={isLoading}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDelete}
-                disabled={isLoading}
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Deleting...
-                  </>
-                ) : (
-                  'Delete'
-                )}
-              </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button variant="destructive" size="sm">
+              <Trash2 className="size-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Delete {entityLabels[entityType]}</p>
+        </TooltipContent>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Delete {entityLabels[entityType]}</DialogTitle>
+            <DialogDescription asChild>
+              <div>
+                Are you sure you want to delete <strong>{entityName}</strong>?
+                This action cannot be undone.
+                <br />
+                <br />
+                <ul className="list-disc pl-4">
+                  <li>This action will cascade to all children.</li>
+                  <li>All associated data will be permanently removed.</li>
+                </ul>
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </Tooltip>
   );
 }

--- a/components/simple-tooltip.tsx
+++ b/components/simple-tooltip.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
 
@@ -14,11 +13,9 @@ export default function SimpleTooltip({
   children: ReactNode;
 }) {
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent>{content}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{content}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/components/tournaments/AcceptPreVerificationStatusesButton.tsx
+++ b/components/tournaments/AcceptPreVerificationStatusesButton.tsx
@@ -74,68 +74,64 @@ export default function AcceptPreVerificationStatusesButton({
   };
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <Dialog open={isOpen} onOpenChange={setIsOpen}>
-          <TooltipTrigger asChild>
-            <DialogTrigger asChild>
-              <Button variant="default" size="sm">
-                <CheckCircle2 className="size-4" />
-              </Button>
-            </DialogTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Accept pre-verification statuses for tournament and children</p>
-          </TooltipContent>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                Confirm Accept Pre-Verification Statuses
-              </DialogTitle>
-              <DialogDescription asChild>
-                <div>
-                  Are you sure you want to accept pre-verification statuses for{' '}
-                  <strong>{tournament.name}</strong>? This action cannot be
-                  undone.
-                  <br />
-                  <br />
-                  <ul className="list-disc pl-4">
-                    <li>Pre-rejected items will be marked as rejected.</li>
-                    <li>Pre-verified items will be marked as verified.</li>
-                    <li>
-                      This action will process the tournament and all its
-                      children (matches, games, scores).
-                    </li>
-                  </ul>
-                </div>
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                onClick={handleCancel}
-                disabled={isLoading}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="default"
-                onClick={handleAccept}
-                disabled={isLoading}
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 size-4 animate-spin" />
-                    Processing...
-                  </>
-                ) : (
-                  'Confirm'
-                )}
-              </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button variant="default" size="sm">
+              <CheckCircle2 className="size-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Accept pre-verification statuses for tournament and children</p>
+        </TooltipContent>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Accept Pre-Verification Statuses</DialogTitle>
+            <DialogDescription asChild>
+              <div>
+                Are you sure you want to accept pre-verification statuses for{' '}
+                <strong>{tournament.name}</strong>? This action cannot be
+                undone.
+                <br />
+                <br />
+                <ul className="list-disc pl-4">
+                  <li>Pre-rejected items will be marked as rejected.</li>
+                  <li>Pre-verified items will be marked as verified.</li>
+                  <li>
+                    This action will process the tournament and all its children
+                    (matches, games, scores).
+                  </li>
+                </ul>
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              onClick={handleAccept}
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Processing...
+                </>
+              ) : (
+                'Confirm'
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </Tooltip>
   );
 }

--- a/components/tournaments/DeleteTournamentBeatmapsButton.tsx
+++ b/components/tournaments/DeleteTournamentBeatmapsButton.tsx
@@ -51,7 +51,6 @@ export default function DeleteTournamentBeatmapsButton({
   };
 
   return (
-    <TooltipProvider>
       <Tooltip>
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
           <TooltipTrigger asChild>
@@ -112,6 +111,5 @@ export default function DeleteTournamentBeatmapsButton({
           </DialogContent>
         </Dialog>
       </Tooltip>
-    </TooltipProvider>
   );
 }

--- a/components/tournaments/ResetAutomatedChecksButton.tsx
+++ b/components/tournaments/ResetAutomatedChecksButton.tsx
@@ -57,7 +57,6 @@ export default function ResetAutomatedChecksButton({
   };
 
   return (
-    <TooltipProvider>
       <Tooltip>
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
           <TooltipTrigger asChild>
@@ -126,6 +125,5 @@ export default function ResetAutomatedChecksButton({
           </DialogContent>
         </Dialog>
       </Tooltip>
-    </TooltipProvider>
   );
 }

--- a/components/tournaments/list/TournamentListFilter.tsx
+++ b/components/tournaments/list/TournamentListFilter.tsx
@@ -235,31 +235,29 @@ const SortControls = ({ control }: { control: Control<FilterFormData> }) => (
       name="descending"
       render={({ field }) => (
         <FormItem>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <FormControl>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => field.onChange(!field.value)}
-                    aria-label={
-                      field.value ? 'Sort Ascending' : 'Sort Descending'
-                    }
-                  >
-                    {field.value ? (
-                      <ArrowDown className="h-4 w-4" />
-                    ) : (
-                      <ArrowUp className="h-4 w-4" />
-                    )}
-                  </Button>
-                </FormControl>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>{field.value ? 'Sort Ascending' : 'Sort Descending'}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <FormControl>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => field.onChange(!field.value)}
+                  aria-label={
+                    field.value ? 'Sort Ascending' : 'Sort Descending'
+                  }
+                >
+                  {field.value ? (
+                    <ArrowDown className="h-4 w-4" />
+                  ) : (
+                    <ArrowUp className="h-4 w-4" />
+                  )}
+                </Button>
+              </FormControl>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{field.value ? 'Sort Ascending' : 'Sort Descending'}</p>
+            </TooltipContent>
+          </Tooltip>
         </FormItem>
       )}
     />

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
     <tr
       data-slot="table-row"
       className={cn(
-        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        'border-b transition-colors data-[state=selected]:bg-muted',
         className
       )}
       {...props}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -21,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({


### PR DESCRIPTION
The large diffs are from where I removed surrounding `<TooltipProvider>` components which aren't needed. Added a top-level `<TooltipProvider>` to the `RootLayout`.

- Re-adds leaderboard tooltips for tier icon
- Adds leaderboard tooltips for country flags
- Cleaned up the leaderboard table files, e.g. removed `PlayerImage` which was a useless wrapper for `Image`

Closes #344