### PR TITLE
Fix regression with combo mod colors

### DIFF
--- a/lib/utils/mods.ts
+++ b/lib/utils/mods.ts
@@ -59,15 +59,15 @@ export function getModColor(mods: Mods) {
       return 'var(--mod-double-time)';
     case Mods.HalfTime:
       return 'var(--mod-half-time)';
-    case Mods.Hidden || Mods.HardRock:
+    case Mods.Hidden | Mods.HardRock:
       return 'var(--mod-hidden-hard-rock)';
-    case Mods.Hidden || Mods.Easy:
+    case Mods.Hidden | Mods.Easy:
       return 'var(--mod-hidden-easy)';
-    case Mods.Easy || Mods.DoubleTime:
+    case Mods.Easy | Mods.DoubleTime:
       return 'var(--mod-easy-double-time)';
-    case Mods.Hidden || Mods.Flashlight:
+    case Mods.Hidden | Mods.Flashlight:
       return 'var(--mod-hidden-flashlight)';
-    case Mods.Hidden || Mods.DoubleTime:
+    case Mods.Hidden | Mods.DoubleTime:
       return 'var(--mod-hidden-double-time)';
     case Mods.SuddenDeath:
       return 'var(--mod-sudden-death)';


### PR DESCRIPTION
Fixes a bug which caused certain mod combinations to not use the correct color in charts.

Before
![image](https://github.com/user-attachments/assets/35595809-595e-4a05-8237-752b0a6dc445)

After
![image](https://github.com/user-attachments/assets/4fbbd9d9-9fb1-46f4-849d-ec87a166df69)
