### PR TITLE
Update to API client v1.1.0 and handle DTO changes

### DIFF
--- a/app/matches/[id]/page.tsx
+++ b/app/matches/[id]/page.tsx
@@ -9,13 +9,13 @@ type PageProps = { params: Promise<{ id: number }> };
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  const match = await get({ id: (await params).id, verified: false });
+  const match = await get({ id: (await params).id });
 
   return { title: match.name };
 }
 
 export default async function Page({ params }: PageProps) {
-  const match = await get({ id: (await params).id, verified: false });
+  const match = await get({ id: (await params).id });
 
   return (
     <Card className="bg-popover">

--- a/components/games/MergeGameButton.tsx
+++ b/components/games/MergeGameButton.tsx
@@ -88,7 +88,7 @@ export default function MergeGameButton({ game }: MergeGameButtonProps) {
     setError(null);
 
     try {
-      const fetchPromises = uniqueIds.map((id) => get({ id, verified: false }));
+      const fetchPromises = uniqueIds.map((id) => get({ id }));
       const fetchedGames = await Promise.all(fetchPromises);
       setTargetGames(fetchedGames);
     } catch {

--- a/components/matches/MatchAdminView.tsx
+++ b/components/matches/MatchAdminView.tsx
@@ -74,7 +74,11 @@ const matchRejectionReasonOptions = Object.entries(
   }))
   .sort((a, b) => a.label.localeCompare(b.label)) satisfies Option[];
 
-export default function MatchAdminView({ match }: { match: MatchCompactDTO | MatchDTO }) {
+export default function MatchAdminView({
+  match,
+}: {
+  match: MatchCompactDTO | MatchDTO;
+}) {
   const defaultValues = {
     name: match.name,
     verificationStatus: match.verificationStatus,

--- a/components/matches/MatchAdminView.tsx
+++ b/components/matches/MatchAdminView.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   MatchCompactDTO,
+  MatchDTO,
   MatchWarningFlags,
   MatchRejectionReason,
   Roles,
@@ -73,10 +74,20 @@ const matchRejectionReasonOptions = Object.entries(
   }))
   .sort((a, b) => a.label.localeCompare(b.label)) satisfies Option[];
 
-export default function MatchAdminView({ match }: { match: MatchCompactDTO }) {
+export default function MatchAdminView({ match }: { match: MatchCompactDTO | MatchDTO }) {
+  const defaultValues = {
+    name: match.name,
+    verificationStatus: match.verificationStatus,
+    rejectionReason: match.rejectionReason,
+    processingStatus: match.processingStatus,
+    warningFlags: match.warningFlags,
+    startTime: match.startTime,
+    endTime: match.endTime,
+  };
+
   const form = useForm<z.infer<typeof matchEditFormSchema>>({
     resolver: zodResolver(matchEditFormSchema),
-    defaultValues: match,
+    defaultValues,
     mode: 'all',
   });
 
@@ -89,12 +100,11 @@ export default function MatchAdminView({ match }: { match: MatchCompactDTO }) {
 
   async function onSubmit(values: z.infer<typeof matchEditFormSchema>) {
     try {
-      const patchedMatch = await update({
+      await update({
         id: match.id,
         body: createPatchOperations(match, values),
       });
 
-      form.reset(patchedMatch);
       saveToast();
       router.refresh();
     } catch {

--- a/components/matches/MergeMatchButton.tsx
+++ b/components/matches/MergeMatchButton.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Loader2, Merge } from 'lucide-react';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
-import { MatchDTO } from '@osu-tournament-rating/otr-api-client';
+import { MatchDTO, MatchCompactDTO } from '@osu-tournament-rating/otr-api-client';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -33,7 +33,7 @@ import RulesetIcon from '@/components/icons/RulesetIcon';
 import SimpleTooltip from '../simple-tooltip';
 
 interface MergeMatchButtonProps {
-  match: MatchDTO;
+  match: MatchDTO | MatchCompactDTO;
 }
 
 const MATCH_ID_SEPARATORS = /[,\s\n]+/;
@@ -94,7 +94,7 @@ export default function MergeMatchButton({ match }: MergeMatchButtonProps) {
     setError(null);
 
     try {
-      const fetchPromises = uniqueIds.map((id) => get({ id, verified: false }));
+      const fetchPromises = uniqueIds.map((id) => get({ id }));
       const fetchedMatches = await Promise.all(fetchPromises);
       setTargetMatches(fetchedMatches);
     } catch {

--- a/components/matches/MergeMatchButton.tsx
+++ b/components/matches/MergeMatchButton.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react';
 import { Loader2, Merge } from 'lucide-react';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
-import { MatchDTO, MatchCompactDTO } from '@osu-tournament-rating/otr-api-client';
+import {
+  MatchDTO,
+  MatchCompactDTO,
+} from '@osu-tournament-rating/otr-api-client';
 
 import { Button } from '@/components/ui/button';
 import {

--- a/lib/actions/games.ts
+++ b/lib/actions/games.ts
@@ -7,11 +7,11 @@ import {
 import { cache } from 'react';
 import { games } from '../api/server';
 
-export const get = async ({ id, verified }: GamesGetRequestParams) =>
-  await getCached(id, verified);
+export const get = async ({ id }: GamesGetRequestParams) =>
+  await getCached(id);
 
-const getCached = cache(async (id: number, verified?: boolean) => {
-  const { result } = await games.get({ id, verified });
+const getCached = cache(async (id: number) => {
+  const { result } = await games.get({ id });
   return result;
 });
 

--- a/lib/actions/games.ts
+++ b/lib/actions/games.ts
@@ -7,8 +7,7 @@ import {
 import { cache } from 'react';
 import { games } from '../api/server';
 
-export const get = async ({ id }: GamesGetRequestParams) =>
-  await getCached(id);
+export const get = async ({ id }: GamesGetRequestParams) => await getCached(id);
 
 const getCached = cache(async (id: number) => {
   const { result } = await games.get({ id });

--- a/lib/actions/matches.ts
+++ b/lib/actions/matches.ts
@@ -7,11 +7,11 @@ import {
 import { cache } from 'react';
 import { matches } from '../api/server';
 
-export const get = async ({ id, verified }: MatchesGetRequestParams) =>
-  await getCached(id, verified);
+export const get = async ({ id }: MatchesGetRequestParams) =>
+  await getCached(id);
 
-const getCached = cache(async (id: number, verified?: boolean) => {
-  const { result } = await matches.get({ id, verified });
+const getCached = cache(async (id: number) => {
+  const { result } = await matches.get({ id });
   return result;
 });
 

--- a/lib/actions/tournaments.ts
+++ b/lib/actions/tournaments.ts
@@ -39,11 +39,11 @@ import { cache } from 'react';
  * Get a tournament
  * @param params see {@link TournamentsGetRequestParams}
  */
-export const get = async ({ id, verified }: TournamentsGetRequestParams) =>
-  await getCached(id, verified);
+export const get = async ({ id }: TournamentsGetRequestParams) =>
+  await getCached(id);
 
-const getCached = cache(async (id: number, verified?: boolean) => {
-  const { result } = await tournaments.get({ id, verified });
+const getCached = cache(async (id: number) => {
+  const { result } = await tournaments.get({ id });
   return result;
 });
 

--- a/lib/utils/form.ts
+++ b/lib/utils/form.ts
@@ -10,13 +10,14 @@ function isValidDateString(str: string): boolean {
   if (typeof str !== 'string') {
     return false;
   }
-  
+
   // Check for ISO 8601 format patterns
-  const isoPattern = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?)?$/;
+  const isoPattern =
+    /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?)?$/;
   if (isoPattern.test(str)) {
     return true;
   }
-  
+
   // Check for other common date formats
   const commonDatePatterns = [
     /^\d{1,2}\/\d{1,2}\/\d{4}$/, // MM/DD/YYYY or M/D/YYYY
@@ -24,8 +25,8 @@ function isValidDateString(str: string): boolean {
     /^\w{3}\s+\d{1,2}\s+\d{4}$/, // Mon DD YYYY
     /^\d{1,2}-\w{3}-\d{4}$/, // DD-Mon-YYYY
   ];
-  
-  return commonDatePatterns.some(pattern => pattern.test(str));
+
+  return commonDatePatterns.some((pattern) => pattern.test(str));
 }
 
 /**

--- a/lib/utils/form.ts
+++ b/lib/utils/form.ts
@@ -4,6 +4,31 @@ import {
 } from '@osu-tournament-rating/otr-api-client';
 
 /**
+ * Check if a string is intended to be parsed as a date
+ */
+function isValidDateString(str: string): boolean {
+  if (typeof str !== 'string') {
+    return false;
+  }
+  
+  // Check for ISO 8601 format patterns
+  const isoPattern = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?)?$/;
+  if (isoPattern.test(str)) {
+    return true;
+  }
+  
+  // Check for other common date formats
+  const commonDatePatterns = [
+    /^\d{1,2}\/\d{1,2}\/\d{4}$/, // MM/DD/YYYY or M/D/YYYY
+    /^\d{4}\/\d{2}\/\d{2}$/, // YYYY/MM/DD
+    /^\w{3}\s+\d{1,2}\s+\d{4}$/, // Mon DD YYYY
+    /^\d{1,2}-\w{3}-\d{4}$/, // DD-Mon-YYYY
+  ];
+  
+  return commonDatePatterns.some(pattern => pattern.test(str));
+}
+
+/**
  * Check if two values represent the same date/time, handling timezone differences
  */
 function areDatesEqual(orig: unknown, patched: unknown): boolean {
@@ -16,16 +41,17 @@ function areDatesEqual(orig: unknown, patched: unknown): boolean {
     return orig === patched;
   }
 
-  // Try to parse as dates
-  const origDate = new Date(orig as string);
-  const patchedDate = new Date(patched as string);
-
-  // If both are valid dates, compare their time values
-  if (!isNaN(origDate.getTime()) && !isNaN(patchedDate.getTime())) {
-    return origDate.getTime() === patchedDate.getTime();
+  // Only attempt date parsing for strings that look like valid dates
+  if (
+    typeof orig === 'string' &&
+    typeof patched === 'string' &&
+    isValidDateString(orig) &&
+    isValidDateString(patched)
+  ) {
+    return new Date(orig).getTime() === new Date(patched).getTime();
   }
 
-  // If not dates, fall back to regular comparison
+  // Not dates, use regular comparison
   return orig === patched;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@alduino/humanizer": "^1.1.0",
         "@hookform/resolvers": "^4.1.3",
-        "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.0",
+        "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.1",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.5",
@@ -2585,9 +2585,9 @@
       }
     },
     "node_modules/@osu-tournament-rating/otr-api-client": {
-      "version": "1.0.1-dev.0",
-      "resolved": "https://registry.npmjs.org/@osu-tournament-rating/otr-api-client/-/otr-api-client-1.0.1-dev.0.tgz",
-      "integrity": "sha512-6yTHkzyG92mjpZyw7sIuVKiROiZj/YWeoRV0MDJ6wtHWCf12w+7vGxWpqLcUslbQH8USTlBsSFrzmwArsluhjQ==",
+      "version": "1.0.1-dev.1",
+      "resolved": "https://registry.npmjs.org/@osu-tournament-rating/otr-api-client/-/otr-api-client-1.0.1-dev.1.tgz",
+      "integrity": "sha512-nj04BuAG3d8RVlwA92K1pUkVMrrI1BNvNSt8VkD1e6G0RFs+oucfuG+OkCV2M7PJHOPuYPMGS6DDvzrxOIVS5A==",
       "dependencies": {
         "axios": "^1.7.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@alduino/humanizer": "^1.1.0",
         "@hookform/resolvers": "^4.1.3",
-        "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.1",
+        "@osu-tournament-rating/otr-api-client": "^1.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.5",
@@ -2585,9 +2585,9 @@
       }
     },
     "node_modules/@osu-tournament-rating/otr-api-client": {
-      "version": "1.0.1-dev.1",
-      "resolved": "https://registry.npmjs.org/@osu-tournament-rating/otr-api-client/-/otr-api-client-1.0.1-dev.1.tgz",
-      "integrity": "sha512-nj04BuAG3d8RVlwA92K1pUkVMrrI1BNvNSt8VkD1e6G0RFs+oucfuG+OkCV2M7PJHOPuYPMGS6DDvzrxOIVS5A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@osu-tournament-rating/otr-api-client/-/otr-api-client-1.1.0.tgz",
+      "integrity": "sha512-QEOaMGTJ0S9kEwNj5SaVEBb9ZOVke/IgkHivF15Jk6i2fjL7q5FLCBQYT577tzo/Ye0enRZZKUfAe8iqBouqbg==",
       "dependencies": {
         "axios": "^1.7.7"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@alduino/humanizer": "^1.1.0",
     "@hookform/resolvers": "^4.1.3",
-    "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.0",
+    "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.1",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@alduino/humanizer": "^1.1.0",
     "@hookform/resolvers": "^4.1.3",
-    "@osu-tournament-rating/otr-api-client": "^1.0.1-dev.1",
+    "@osu-tournament-rating/otr-api-client": "^1.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.5",


### PR DESCRIPTION
Updated the API client to v1.1.0 and adapted to breaking changes in the DTOs. The verified parameter was removed from get endpoints, and tournament pages now handle MatchCompactDTO instead of MatchDTO. Fixed an edge case in patch operations where non-date strings were incorrectly parsed as dates.