### PR TITLE
Add `X-Api-Key` header for all requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_API_BASE_URL="http://localhost:5075"
 NEXT_PUBLIC_APP_BASE_URL="http://localhost:3000"
 IS_RESTRICTED_ENV=false
+API_KEY=abcdefgh

--- a/lib/api/server.ts
+++ b/lib/api/server.ts
@@ -29,11 +29,14 @@ const config: IOtrApiWrapperConfiguration = {
   postConfigureClientMethod: (instance) => {
     instance.interceptors.request.use(
       async (config) => {
+        const apiHeaderKey = 'X-Api-Key';
+        const apiHeaderValue = process.env.API_KEY;
         const authCookie = (await cookies()).get(SESSION_COOKIE_NAME)?.value;
 
         // Always attach session cookie if it exists
         if (authCookie) {
           config.headers['Cookie'] = `${SESSION_COOKIE_NAME}=${authCookie}`;
+          config.headers[apiHeaderKey] = apiHeaderValue;
         }
 
         return config;

--- a/lib/api/server.ts
+++ b/lib/api/server.ts
@@ -31,12 +31,16 @@ const config: IOtrApiWrapperConfiguration = {
       async (config) => {
         const apiHeaderKey = 'X-Api-Key';
         const apiHeaderValue = process.env.API_KEY;
+
         const authCookie = (await cookies()).get(SESSION_COOKIE_NAME)?.value;
 
-        // Always attach session cookie if it exists
+        // Always attach X-Api-Key value, without this, many requests will fail
+        // for unauthorized users.
+        config.headers[apiHeaderKey] = apiHeaderValue;
+
+        // Attach session cookie if it exists
         if (authCookie) {
           config.headers['Cookie'] = `${SESSION_COOKIE_NAME}=${authCookie}`;
-          config.headers[apiHeaderKey] = apiHeaderValue;
         }
 
         return config;


### PR DESCRIPTION
Adds `X-Api-Key` header for all requests. This is a custom header which is effectively a handshake with the API. This header is only attached to server-side requests (which is most if not all meaningful API requests made by the website).