### PR TITLE
fix: public display of tournament submission page

### DIFF
--- a/app/tournaments/submit/page.tsx
+++ b/app/tournaments/submit/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description: 'Submit a tournament to be included in the rating system',
 };
 
-export default function TournamentSubmissionPage() {
+export default async function TournamentSubmissionPage() {
   return (
     <div className="mx-auto flex w-full flex-col items-center justify-center gap-3">
       <Card className="flex w-full flex-col items-center justify-center gap-4">

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -65,7 +65,7 @@ const navItems: NavItem[] = [
         title: 'Submit',
         href: '/tournaments/submit',
         icon: Upload,
-        roles: [Roles.Submit],
+        roles: [Roles.Submit, Roles.Admin],
         requiresSession: true,
       },
     ],
@@ -284,11 +284,11 @@ function NavigationItem({
           <div className="pointer-events-none absolute bottom-0 left-0 hidden h-10/11 w-full rounded-b-xl border border-t-0 border-muted bg-transparent md:block" />
           {dropdown.map(
             ({ title, href, icon: Icon, roles, requiresSession }) => {
-              const isHidden = requiresSession
-                ? !session
-                : roles &&
+              const isHidden =
+                (requiresSession && !session) ||
+                (roles &&
                   roles.length > 0 &&
-                  !roles.some((role) => session?.scopes?.includes(role));
+                  !roles.some((role) => session?.scopes?.includes(role)));
 
               return (
                 <NavLink


### PR DESCRIPTION
This change fixes a bug where users without the Submit or Admin roles could still see the "Tournaments/Submit" navigation menu link.

The issue was in the dropdown visibility logic which used a ternary operator that checked either `requiresSession` or `roles`, but not both. For menu items with both requirements (like Submit), it only verified authentication status, ignoring role requirements.

The fix updates the logic to properly check both conditions:
- Hide if the item requires a session AND there's no session
- Hide if the item requires specific roles AND the user lacks those roles