### PR TITLE
Add beatmap management to tournaments page

### DIFF
--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -31,7 +31,7 @@ import { AdminNoteRouteTarget } from '@osu-tournament-rating/otr-api-client';
 import AdminNoteView from '@/components/admin-notes/AdminNoteView';
 import TournamentAdminView from '@/components/tournaments/TournamentAdminView';
 import RulesetIcon from '@/components/icons/RulesetIcon';
-import TournamentBeatmapsView from '@/components/tournaments/TournamentBeatmapsView';
+import TournamentBeatmapsAdminView from '@/components/tournaments/TournamentBeatmapsAdminView';
 import TournamentPlayerStatsDashboard from '@/components/tournaments/TournamentPlayerStatsDashboard';
 import { Button } from '@/components/ui/button';
 import SimpleTooltip from '@/components/simple-tooltip';
@@ -341,7 +341,9 @@ export default async function Page({ params }: PageProps) {
                 {hiddenBeatmapsCount > 0 && `, ${hiddenBeatmapsCount} deleted`})
               </span>
             </div>
-            <TournamentBeatmapsView
+            <TournamentBeatmapsAdminView
+              tournamentId={tournament.id}
+              tournamentName={tournament.name}
               beatmaps={beatmaps}
               tournamentGames={tournamentGames}
             />

--- a/components/tournaments/TournamentBeatmapsAdminView.tsx
+++ b/components/tournaments/TournamentBeatmapsAdminView.tsx
@@ -36,12 +36,10 @@ interface TournamentBeatmapsAdminViewProps {
   tournamentGames?: GameDTO[];
 }
 
-// Constants
 const UNKNOWN_ARTIST = 'Unknown Artist';
 const UNKNOWN_TITLE = 'Unknown Title';
 const UNKNOWN_DIFFICULTY = 'Unknown Difficulty';
 
-// Helper functions
 const isDeletedBeatmap = (beatmap: BeatmapDTO): boolean => {
   const artist = beatmap.beatmapset?.artist || UNKNOWN_ARTIST;
   const title = beatmap.beatmapset?.title || UNKNOWN_TITLE;
@@ -78,14 +76,12 @@ export default function TournamentBeatmapsAdminView({
 
   const isAdmin = session?.scopes?.includes(Roles.Admin) ?? false;
 
-  // Memoized filtered beatmaps
   const filteredBeatmaps = useMemo(
     () =>
       showDeleted ? beatmaps : beatmaps.filter((b) => !isDeletedBeatmap(b)),
     [showDeleted, beatmaps]
   );
 
-  // Memoized beatmaps with checkbox state
   const beatmapsWithSelection = useMemo(
     () =>
       filteredBeatmaps.map((beatmap) => ({
@@ -96,7 +92,6 @@ export default function TournamentBeatmapsAdminView({
     [filteredBeatmaps, selectedBeatmapIds]
   );
 
-  // Count of deleted beatmaps
   const deletedBeatmapsCount = useMemo(
     () => beatmaps.filter(isDeletedBeatmap).length,
     [beatmaps]

--- a/components/tournaments/TournamentBeatmapsAdminView.tsx
+++ b/components/tournaments/TournamentBeatmapsAdminView.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import {
+  BeatmapDTO,
+  GameDTO,
+  Roles,
+} from '@osu-tournament-rating/otr-api-client';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useSession } from '@/lib/hooks/useSession';
+import {
+  insertBeatmaps,
+  deleteSpecificBeatmaps,
+} from '@/lib/actions/tournaments';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import TournamentBeatmapsView from './TournamentBeatmapsView';
+import TournamentBeatmapsViewWithCheckboxes from './TournamentBeatmapsViewWithCheckboxes';
+
+interface TournamentBeatmapsAdminViewProps {
+  tournamentId: number;
+  tournamentName: string;
+  beatmaps: BeatmapDTO[];
+  tournamentGames?: GameDTO[];
+}
+
+export default function TournamentBeatmapsAdminView({
+  tournamentId,
+  tournamentName,
+  beatmaps,
+  tournamentGames = [],
+}: TournamentBeatmapsAdminViewProps) {
+  const session = useSession();
+  const router = useRouter();
+  const [selectedBeatmapIds, setSelectedBeatmapIds] = useState<Set<number>>(
+    new Set()
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [beatmapIdsToAdd, setBeatmapIdsToAdd] = useState('');
+
+  const isAdmin = session?.scopes?.includes(Roles.Admin) ?? false;
+
+  const handleSelectBeatmap = (beatmapId: number, checked: boolean) => {
+    setSelectedBeatmapIds((prev) => {
+      const newSet = new Set(prev);
+      if (checked) {
+        newSet.add(beatmapId);
+      } else {
+        newSet.delete(beatmapId);
+      }
+      return newSet;
+    });
+  };
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedBeatmapIds(new Set(beatmaps.map((b) => b.id)));
+    } else {
+      setSelectedBeatmapIds(new Set());
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (selectedBeatmapIds.size === 0) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteSpecificBeatmaps(
+        tournamentId,
+        Array.from(selectedBeatmapIds)
+      );
+      toast.success(
+        `Successfully removed ${selectedBeatmapIds.size} beatmap${
+          selectedBeatmapIds.size === 1 ? '' : 's'
+        }`
+      );
+      setSelectedBeatmapIds(new Set());
+      setIsDeleteDialogOpen(false);
+      router.refresh();
+    } catch (error) {
+      toast.error('Failed to remove beatmaps');
+      console.error('Error removing beatmaps:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleAddBeatmaps = async () => {
+    const ids = beatmapIdsToAdd
+      .split(/[,\n]+/)
+      .map((id) => id.trim())
+      .filter((id) => id)
+      .map((id) => parseInt(id, 10))
+      .filter((id) => !isNaN(id));
+
+    if (ids.length === 0) {
+      toast.error('Please enter valid beatmap IDs');
+      return;
+    }
+
+    setIsAdding(true);
+    try {
+      await insertBeatmaps(tournamentId, ids);
+      toast.success(
+        `Successfully added ${ids.length} beatmap${ids.length === 1 ? '' : 's'}`
+      );
+      setBeatmapIdsToAdd('');
+      setIsAddDialogOpen(false);
+      router.refresh();
+    } catch (error) {
+      toast.error('Failed to add beatmaps');
+      console.error('Error adding beatmaps:', error);
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <TournamentBeatmapsView
+        beatmaps={beatmaps}
+        tournamentGames={tournamentGames}
+      />
+    );
+  }
+
+  // Create beatmaps with checkbox state
+  const beatmapsWithSelection = beatmaps.map((beatmap) => ({
+    ...beatmap,
+    isSelected: selectedBeatmapIds.has(beatmap.id),
+  }));
+
+  return (
+    <div className="space-y-4">
+      {/* Admin action bar */}
+      <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={
+              beatmaps.length > 0 && selectedBeatmapIds.size === beatmaps.length
+            }
+            onCheckedChange={handleSelectAll}
+            aria-label="Select all beatmaps"
+          />
+          <span className="text-sm text-muted-foreground">
+            {selectedBeatmapIds.size > 0
+              ? `${selectedBeatmapIds.size} selected`
+              : 'Select beatmaps'}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* Delete selected button */}
+          {selectedBeatmapIds.size > 0 && (
+            <Dialog
+              open={isDeleteDialogOpen}
+              onOpenChange={setIsDeleteDialogOpen}
+            >
+              <DialogTrigger asChild>
+                <Button variant="destructive" size="sm">
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Remove Selected ({selectedBeatmapIds.size})
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Confirm Beatmap Removal</DialogTitle>
+                  <DialogDescription asChild>
+                    <div>
+                      Are you sure you want to remove{' '}
+                      <strong>{selectedBeatmapIds.size}</strong> beatmap
+                      {selectedBeatmapIds.size === 1 ? '' : 's'} from{' '}
+                      <strong>{tournamentName}</strong>?
+                      <br />
+                      <br />
+                      <ul className="list-disc pl-4">
+                        <li>
+                          This will unlink the selected beatmaps from the
+                          tournament.
+                        </li>
+                        <li>
+                          The beatmaps themselves will not be deleted from the
+                          system.
+                        </li>
+                      </ul>
+                    </div>
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsDeleteDialogOpen(false)}
+                    disabled={isDeleting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={handleDeleteSelected}
+                    disabled={isDeleting}
+                  >
+                    {isDeleting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Removing...
+                      </>
+                    ) : (
+                      <>
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Remove Beatmaps
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
+          )}
+
+          {/* Add beatmaps button */}
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="mr-2 h-4 w-4" />
+                Add Beatmaps
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Add Beatmaps</DialogTitle>
+                <DialogDescription>
+                  Enter osu! beatmap IDs to add to the tournament pool. You can
+                  enter multiple IDs separated by commas or new lines.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <Textarea
+                  placeholder="Enter beatmap IDs (e.g., 1234567, 2345678)"
+                  value={beatmapIdsToAdd}
+                  onChange={(e) => setBeatmapIdsToAdd(e.target.value)}
+                  rows={5}
+                  className="font-mono"
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setIsAddDialogOpen(false);
+                      setBeatmapIdsToAdd('');
+                    }}
+                    disabled={isAdding}
+                  >
+                    Cancel
+                  </Button>
+                  <Button onClick={handleAddBeatmaps} disabled={isAdding}>
+                    {isAdding ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Adding...
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Add Beatmaps
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      {/* Modified beatmaps view with checkboxes */}
+      <div className="relative">
+        <TournamentBeatmapsViewWithCheckboxes
+          beatmaps={beatmapsWithSelection}
+          tournamentGames={tournamentGames}
+          onSelectBeatmap={handleSelectBeatmap}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/tournaments/TournamentBeatmapsAdminView.tsx
+++ b/components/tournaments/TournamentBeatmapsAdminView.tsx
@@ -25,12 +25,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import SimpleTooltip from '@/components/simple-tooltip';
 import TournamentBeatmapsView from './TournamentBeatmapsView';
 import TournamentBeatmapsViewWithCheckboxes from './TournamentBeatmapsViewWithCheckboxes';
 
@@ -362,36 +357,28 @@ export default function TournamentBeatmapsAdminView({
             </DialogContent>
           </Dialog>
 
-          {/* Spacer to push the eye button to the right */}
-          <div className="flex-1" />
-
           {/* Show deleted toggle - far right with just icon */}
           {beatmaps.some(isDeletedBeatmap) && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setShowDeleted(!showDeleted)}
-                    className="h-8 w-8 p-0"
-                  >
-                    {showDeleted ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>
-                    {showDeleted
-                      ? `Hide deleted beatmaps`
-                      : `Show ${beatmaps.filter(isDeletedBeatmap).length} deleted beatmap${beatmaps.filter(isDeletedBeatmap).length === 1 ? '' : 's'}`}
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <SimpleTooltip
+              content={
+                showDeleted
+                  ? `Hide deleted beatmaps`
+                  : `Show ${beatmaps.filter(isDeletedBeatmap).length} deleted beatmap${beatmaps.filter(isDeletedBeatmap).length === 1 ? '' : 's'}`
+              }
+            >
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowDeleted(!showDeleted)}
+                className="h-8 w-8 p-0"
+              >
+                {showDeleted ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </Button>
+            </SimpleTooltip>
           )}
         </div>
       </div>

--- a/components/tournaments/TournamentBeatmapsAdminView.tsx
+++ b/components/tournaments/TournamentBeatmapsAdminView.tsx
@@ -146,7 +146,7 @@ export default function TournamentBeatmapsAdminView({
   }));
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {/* Admin action bar */}
       <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-3">
         <div className="flex items-center gap-2">
@@ -160,7 +160,7 @@ export default function TournamentBeatmapsAdminView({
           <span className="text-sm text-muted-foreground">
             {selectedBeatmapIds.size > 0
               ? `${selectedBeatmapIds.size} selected`
-              : 'Select beatmaps'}
+              : 'Select all'}
           </span>
         </div>
 
@@ -244,7 +244,8 @@ export default function TournamentBeatmapsAdminView({
                 <DialogTitle>Add Beatmaps</DialogTitle>
                 <DialogDescription>
                   Enter osu! beatmap IDs to add to the tournament pool. You can
-                  enter multiple IDs separated by commas or new lines.
+                  enter multiple IDs separated by commas or new lines.{' '}
+                  <strong>Duplicates are safely ignored.</strong>
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
@@ -269,12 +270,12 @@ export default function TournamentBeatmapsAdminView({
                   <Button onClick={handleAddBeatmaps} disabled={isAdding}>
                     {isAdding ? (
                       <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <Loader2 className="h-4 w-4 animate-spin" />
                         Adding...
                       </>
                     ) : (
                       <>
-                        <Plus className="mr-2 h-4 w-4" />
+                        <Plus className="h-4 w-4" />
                         Add Beatmaps
                       </>
                     )}

--- a/components/tournaments/TournamentBeatmapsAdminView.tsx
+++ b/components/tournaments/TournamentBeatmapsAdminView.tsx
@@ -7,7 +7,7 @@ import {
 } from '@osu-tournament-rating/otr-api-client';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { Loader2, Plus, Trash2 } from 'lucide-react';
+import { Loader2, Plus, Trash2, Eye, EyeOff } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/lib/hooks/useSession';
 import {
@@ -25,6 +25,12 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import TournamentBeatmapsView from './TournamentBeatmapsView';
 import TournamentBeatmapsViewWithCheckboxes from './TournamentBeatmapsViewWithCheckboxes';
 
@@ -52,6 +58,7 @@ export default function TournamentBeatmapsAdminView({
   const [isAdding, setIsAdding] = useState(false);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [beatmapIdsToAdd, setBeatmapIdsToAdd] = useState('');
+  const [showDeleted, setShowDeleted] = useState(false);
 
   const isAdmin = session?.scopes?.includes(Roles.Admin) ?? false;
 
@@ -69,7 +76,7 @@ export default function TournamentBeatmapsAdminView({
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
-      setSelectedBeatmapIds(new Set(beatmaps.map((b) => b.id)));
+      setSelectedBeatmapIds(new Set(filteredBeatmaps.map((b) => b.id)));
     } else {
       setSelectedBeatmapIds(new Set());
     }
@@ -139,10 +146,22 @@ export default function TournamentBeatmapsAdminView({
     );
   }
 
+  // Filter beatmaps based on showDeleted state
+  const isDeletedBeatmap = (beatmap: BeatmapDTO) => {
+    const artist = beatmap.beatmapset?.artist || 'Unknown Artist';
+    const title = beatmap.beatmapset?.title || 'Unknown Title';
+    return artist === 'Unknown Artist' && title === 'Unknown Title';
+  };
+
+  const filteredBeatmaps = showDeleted
+    ? beatmaps
+    : beatmaps.filter((b) => !isDeletedBeatmap(b));
+
   // Create beatmaps with checkbox state
-  const beatmapsWithSelection = beatmaps.map((beatmap) => ({
+  const beatmapsWithSelection = filteredBeatmaps.map((beatmap) => ({
     ...beatmap,
     isSelected: selectedBeatmapIds.has(beatmap.id),
+    isDeleted: isDeletedBeatmap(beatmap),
   }));
 
   return (
@@ -152,7 +171,8 @@ export default function TournamentBeatmapsAdminView({
         <div className="flex items-center gap-2">
           <Checkbox
             checked={
-              beatmaps.length > 0 && selectedBeatmapIds.size === beatmaps.length
+              filteredBeatmaps.length > 0 &&
+              selectedBeatmapIds.size === filteredBeatmaps.length
             }
             onCheckedChange={handleSelectAll}
             aria-label="Select all beatmaps"
@@ -177,7 +197,7 @@ export default function TournamentBeatmapsAdminView({
                   Remove Selected ({selectedBeatmapIds.size})
                 </Button>
               </DialogTrigger>
-              <DialogContent>
+              <DialogContent className="flex max-h-[80vh] max-w-2xl flex-col overflow-hidden">
                 <DialogHeader>
                   <DialogTitle>Confirm Beatmap Removal</DialogTitle>
                   <DialogDescription asChild>
@@ -186,21 +206,79 @@ export default function TournamentBeatmapsAdminView({
                       <strong>{selectedBeatmapIds.size}</strong> beatmap
                       {selectedBeatmapIds.size === 1 ? '' : 's'} from{' '}
                       <strong>{tournamentName}</strong>?
-                      <br />
-                      <br />
-                      <ul className="list-disc pl-4">
-                        <li>
-                          This will unlink the selected beatmaps from the
-                          tournament.
-                        </li>
-                        <li>
-                          The beatmaps themselves will not be deleted from the
-                          system.
-                        </li>
-                      </ul>
                     </div>
                   </DialogDescription>
                 </DialogHeader>
+
+                {/* Beatmap summary section */}
+                <div className="flex-1 space-y-3 overflow-y-auto py-2">
+                  <div className="rounded-lg border bg-muted/30 p-3">
+                    <p className="mb-2 text-sm font-medium">
+                      Beatmaps to be removed:
+                    </p>
+                    <div className="max-h-60 space-y-1 overflow-y-auto">
+                      {Array.from(selectedBeatmapIds).map((beatmapId) => {
+                        const beatmap = beatmaps.find(
+                          (b) => b.id === beatmapId
+                        );
+                        if (!beatmap) return null;
+                        const artist =
+                          beatmap.beatmapset?.artist || 'Unknown Artist';
+                        const title =
+                          beatmap.beatmapset?.title || 'Unknown Title';
+                        const version =
+                          beatmap.diffName || 'Unknown Difficulty';
+                        const isDeleted =
+                          artist === 'Unknown Artist' &&
+                          title === 'Unknown Title';
+
+                        return (
+                          <div
+                            key={beatmapId}
+                            className="rounded px-2 py-1 text-sm hover:bg-muted/50"
+                          >
+                            <div className="flex items-start gap-2">
+                              <a
+                                href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="min-w-[3rem] text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-primary"
+                              >
+                                #{beatmap.osuId || beatmapId}
+                              </a>
+                              <div className="flex-1">
+                                <span
+                                  className={
+                                    isDeleted ? 'line-through opacity-50' : ''
+                                  }
+                                >
+                                  {artist} - {title} [{version}]
+                                </span>
+                                {isDeleted && (
+                                  <span className="ml-2 text-xs text-muted-foreground">
+                                    (Deleted from osu!)
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="space-y-1 text-sm text-muted-foreground">
+                    <p>
+                      • This will unlink the selected beatmaps from the
+                      tournament
+                    </p>
+                    <p>
+                      • The beatmaps themselves will not be deleted from the
+                      system
+                    </p>
+                    <p>• This action cannot be undone</p>
+                  </div>
+                </div>
                 <div className="flex justify-end gap-2">
                   <Button
                     variant="outline"
@@ -230,7 +308,6 @@ export default function TournamentBeatmapsAdminView({
               </DialogContent>
             </Dialog>
           )}
-
           {/* Add beatmaps button */}
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
             <DialogTrigger asChild>
@@ -284,6 +361,38 @@ export default function TournamentBeatmapsAdminView({
               </div>
             </DialogContent>
           </Dialog>
+
+          {/* Spacer to push the eye button to the right */}
+          <div className="flex-1" />
+
+          {/* Show deleted toggle - far right with just icon */}
+          {beatmaps.some(isDeletedBeatmap) && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setShowDeleted(!showDeleted)}
+                    className="h-8 w-8 p-0"
+                  >
+                    {showDeleted ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {showDeleted
+                      ? `Hide deleted beatmaps`
+                      : `Show ${beatmaps.filter(isDeletedBeatmap).length} deleted beatmap${beatmaps.filter(isDeletedBeatmap).length === 1 ? '' : 's'}`}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
       </div>
 

--- a/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
+++ b/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
@@ -1,0 +1,436 @@
+'use client';
+
+import { BeatmapDTO, GameDTO } from '@osu-tournament-rating/otr-api-client';
+import {
+  Music,
+  Star,
+  Clock,
+  Activity,
+  User,
+  ChevronUp,
+  ChevronDown,
+  Gamepad2,
+} from 'lucide-react';
+import { formatDuration } from '@/lib/utils/date';
+import { getMostCommonModForBeatmap } from '@/lib/utils/mods';
+import Link from 'next/link';
+import SimpleTooltip from '@/components/simple-tooltip';
+import SingleModIcon from '@/components/icons/SingleModIcon';
+import { useState, useMemo } from 'react';
+import BeatmapBackground from '../games/BeatmapBackground';
+import { Checkbox } from '@/components/ui/checkbox';
+
+interface TournamentBeatmapsViewWithCheckboxesProps {
+  beatmaps: (BeatmapDTO & { isSelected: boolean })[];
+  tournamentGames?: GameDTO[];
+  onSelectBeatmap: (beatmapId: number, checked: boolean) => void;
+}
+
+type SortField =
+  | 'title'
+  | 'difficulty'
+  | 'sr'
+  | 'length'
+  | 'bpm'
+  | 'cs'
+  | 'ar'
+  | 'od'
+  | 'hp'
+  | 'mod'
+  | 'gameCount'
+  | 'creator';
+type SortDirection = 'asc' | 'desc';
+
+export default function TournamentBeatmapsViewWithCheckboxes({
+  beatmaps,
+  tournamentGames = [],
+  onSelectBeatmap,
+}: TournamentBeatmapsViewWithCheckboxesProps) {
+  const [sortField, setSortField] = useState<SortField>('gameCount');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection(field === 'sr' ? 'desc' : 'asc');
+    }
+  };
+
+  const sortedBeatmaps = useMemo(() => {
+    return [...beatmaps]
+      .filter((beatmap) => {
+        const artist = beatmap.beatmapset?.artist || 'Unknown Artist';
+        const title = beatmap.beatmapset?.title || 'Unknown Title';
+        return !(artist === 'Unknown Artist' && title === 'Unknown Title');
+      })
+      .sort((a, b) => {
+        let aValue: string | number;
+        let bValue: string | number;
+
+        switch (sortField) {
+          case 'title':
+            aValue = a.beatmapset?.title?.toLowerCase() || '';
+            bValue = b.beatmapset?.title?.toLowerCase() || '';
+            break;
+          case 'difficulty':
+            aValue = a.diffName?.toLowerCase() || '';
+            bValue = b.diffName?.toLowerCase() || '';
+            break;
+          case 'sr':
+            aValue = a.sr;
+            bValue = b.sr;
+            break;
+          case 'length':
+            aValue = a.totalLength;
+            bValue = b.totalLength;
+            break;
+          case 'bpm':
+            aValue = a.bpm || 0;
+            bValue = b.bpm || 0;
+            break;
+          case 'cs':
+            aValue = a.cs || 0;
+            bValue = b.cs || 0;
+            break;
+          case 'ar':
+            aValue = a.ar || 0;
+            bValue = b.ar || 0;
+            break;
+          case 'od':
+            aValue = a.od || 0;
+            bValue = b.od || 0;
+            break;
+          case 'hp':
+            aValue = a.hp || 0;
+            bValue = b.hp || 0;
+            break;
+          case 'mod':
+            {
+              const aModData = getMostCommonModForBeatmap(
+                a.osuId,
+                tournamentGames
+              );
+              const bModData = getMostCommonModForBeatmap(
+                b.osuId,
+                tournamentGames
+              );
+              aValue = aModData?.mod ?? -1;
+              bValue = bModData?.mod ?? -1;
+            }
+            break;
+          case 'gameCount':
+            {
+              const aModData = getMostCommonModForBeatmap(
+                a.osuId,
+                tournamentGames
+              );
+              const bModData = getMostCommonModForBeatmap(
+                b.osuId,
+                tournamentGames
+              );
+              aValue = aModData?.gameCount ?? 0;
+              bValue = bModData?.gameCount ?? 0;
+            }
+            break;
+          case 'creator':
+            aValue = a.beatmapset?.creator?.username?.toLowerCase() || '';
+            bValue = b.beatmapset?.creator?.username?.toLowerCase() || '';
+            break;
+          default:
+            return 0;
+        }
+
+        if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+        if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+        return 0;
+      });
+  }, [beatmaps, sortField, sortDirection, tournamentGames]);
+
+  const SortButton = ({
+    field,
+    children,
+  }: {
+    field: SortField;
+    children: React.ReactNode;
+  }) => (
+    <button
+      onClick={() => handleSort(field)}
+      className="flex items-center gap-1 transition-colors hover:text-foreground"
+    >
+      {children}
+      {sortField === field &&
+        (sortDirection === 'asc' ? (
+          <ChevronUp className="h-3 w-3" />
+        ) : (
+          <ChevronDown className="h-3 w-3" />
+        ))}
+    </button>
+  );
+
+  if (beatmaps.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Music className="mb-4 h-12 w-12 text-muted-foreground" />
+        <h3 className="text-lg font-semibold text-muted-foreground">
+          No Beatmaps Found
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          This tournament has no pooled beatmaps.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Compact table */}
+      <div className="overflow-hidden rounded-lg border">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            {/* Header */}
+            <thead className="border-b bg-muted/50">
+              <tr>
+                <th className="w-[5%] px-2 py-2">
+                  {/* Checkbox column header - empty */}
+                </th>
+                <th className="w-[10%] px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground">
+                  <SortButton field="title">Beatmap</SortButton>
+                </th>
+                <th className="w-[10%] px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground">
+                  <SortButton field="difficulty">Difficulty</SortButton>
+                </th>
+                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Star Rating">
+                    <div className="flex justify-center">
+                      <SortButton field="sr">
+                        <Star className="h-3 w-3" />
+                      </SortButton>
+                    </div>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Length">
+                    <div className="flex justify-center">
+                      <SortButton field="length">
+                        <Clock className="h-3 w-3" />
+                      </SortButton>
+                    </div>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="BPM">
+                    <div className="flex justify-center">
+                      <SortButton field="bpm">
+                        <Activity className="h-3 w-3" />
+                      </SortButton>
+                    </div>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Circle Size">
+                    <SortButton field="cs">CS</SortButton>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Approach Rate">
+                    <SortButton field="ar">AR</SortButton>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Overall Difficulty">
+                    <SortButton field="od">OD</SortButton>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="HP Drain Rate">
+                    <SortButton field="hp">HP</SortButton>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[5%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Most Common Mod">
+                    <SortButton field="mod">Mod</SortButton>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[5%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SimpleTooltip content="Number of Games">
+                    <div className="flex justify-center">
+                      <SortButton field="gameCount">
+                        <Gamepad2 className="h-3 w-3" />
+                      </SortButton>
+                    </div>
+                  </SimpleTooltip>
+                </th>
+                <th className="w-[7%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                  <SortButton field="creator">Creator</SortButton>
+                </th>
+              </tr>
+            </thead>
+
+            {/* Body */}
+            <tbody className="divide-y divide-border">
+              {sortedBeatmaps.map((beatmap) => {
+                const modData = getMostCommonModForBeatmap(
+                  beatmap.osuId,
+                  tournamentGames
+                );
+
+                return (
+                  <tr
+                    key={beatmap.id}
+                    className="group transition-colors hover:bg-muted/30"
+                  >
+                    {/* Checkbox */}
+                    <td className="px-2 py-2 text-center">
+                      <Checkbox
+                        checked={beatmap.isSelected}
+                        onCheckedChange={(checked) =>
+                          onSelectBeatmap(beatmap.id, checked as boolean)
+                        }
+                        aria-label={`Select ${beatmap.beatmapset?.title || 'beatmap'}`}
+                      />
+                    </td>
+
+                    {/* Beatmap Info */}
+                    <td className="px-2 py-2">
+                      <div className="flex items-center gap-2">
+                        {/* Thumbnail */}
+                        <div className="relative h-10 w-16 flex-shrink-0 overflow-hidden rounded">
+                          {beatmap.beatmapset?.osuId ? (
+                            <BeatmapBackground
+                              beatmapsetId={beatmap.beatmapset?.osuId}
+                              alt={`${beatmap.beatmapset?.title} cover`}
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-muted">
+                              <Music className="h-3 w-3 text-muted-foreground" />
+                            </div>
+                          )}
+                        </div>
+
+                        {/* Song details */}
+                        <div className="min-w-0 flex-1">
+                          <Link
+                            href={`https://osu.ppy.sh/b/${beatmap.osuId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block transition-colors hover:text-primary"
+                          >
+                            <p className="max-w-[160px] truncate text-xs font-medium">
+                              {beatmap.beatmapset?.title || 'Unknown Title'}
+                            </p>
+                            <p className="max-w-[140px] truncate text-xs text-muted-foreground">
+                              by{' '}
+                              {beatmap.beatmapset?.artist || 'Unknown Artist'}
+                            </p>
+                          </Link>
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* Difficulty */}
+                    <td className="px-2 py-2">
+                      <span className="block max-w-[100px] truncate text-xs font-medium">
+                        {beatmap.diffName || 'Unknown'}
+                      </span>
+                    </td>
+
+                    {/* Star Rating */}
+                    <td className="px-2 py-2 text-center">
+                      <div className="flex items-center justify-center gap-1">
+                        <Star className="h-3 w-3 fill-yellow-500 text-yellow-500" />
+                        <span className="text-xs font-medium">
+                          {beatmap.sr.toFixed(2)}
+                        </span>
+                      </div>
+                    </td>
+
+                    {/* Length */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">
+                        {formatDuration(beatmap.totalLength)}
+                      </span>
+                    </td>
+
+                    {/* BPM */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">
+                        {beatmap.bpm ? Math.round(beatmap.bpm) : 'N/A'}
+                      </span>
+                    </td>
+
+                    {/* CS */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">{beatmap.cs}</span>
+                    </td>
+
+                    {/* AR */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">{beatmap.ar}</span>
+                    </td>
+
+                    {/* OD */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">{beatmap.od}</span>
+                    </td>
+
+                    {/* HP */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs">
+                        {beatmap.hp !== undefined ? beatmap.hp : 'N/A'}
+                      </span>
+                    </td>
+
+                    {/* Most Common Mod */}
+                    <td className="px-2 py-2 text-center">
+                      <div className="flex items-center justify-center">
+                        {modData ? (
+                          <SingleModIcon mods={modData.mod} size={28} />
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            N/A
+                          </span>
+                        )}
+                      </div>
+                    </td>
+
+                    {/* Game Count */}
+                    <td className="px-2 py-2 text-center">
+                      <span className="text-xs font-medium">
+                        {modData?.gameCount ?? 0}
+                      </span>
+                    </td>
+
+                    {/* Creator */}
+                    <td className="px-2 py-2 text-center">
+                      <div className="flex items-center">
+                        {beatmap.beatmapset?.creator ? (
+                          <Link
+                            href={`https://osu.ppy.sh/users/${beatmap.beatmapset.creator.osuId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex max-w-[120px] items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-primary"
+                          >
+                            <User className="h-3 w-3 flex-shrink-0" />
+                            <span className="truncate">
+                              {beatmap.beatmapset.creator.username}
+                            </span>
+                          </Link>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            Unknown
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
+++ b/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
@@ -16,141 +16,56 @@ import { getMostCommonModForBeatmap } from '@/lib/utils/mods';
 import Link from 'next/link';
 import SimpleTooltip from '@/components/simple-tooltip';
 import SingleModIcon from '@/components/icons/SingleModIcon';
-import { useState, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import BeatmapBackground from '../games/BeatmapBackground';
 import { Checkbox } from '@/components/ui/checkbox';
+import { useBeatmapSort, type SortField } from '@/lib/hooks/useBeatmapSort';
+
+interface ExtendedBeatmapDTO extends BeatmapDTO {
+  isSelected: boolean;
+  isDeleted?: boolean;
+}
 
 interface TournamentBeatmapsViewWithCheckboxesProps {
-  beatmaps: (BeatmapDTO & { isSelected: boolean; isDeleted?: boolean })[];
+  beatmaps: ExtendedBeatmapDTO[];
   tournamentGames?: GameDTO[];
   onSelectBeatmap: (beatmapId: number, checked: boolean) => void;
 }
 
-type SortField =
-  | 'title'
-  | 'difficulty'
-  | 'sr'
-  | 'length'
-  | 'bpm'
-  | 'cs'
-  | 'ar'
-  | 'od'
-  | 'hp'
-  | 'mod'
-  | 'gameCount'
-  | 'creator';
-type SortDirection = 'asc' | 'desc';
+// Table column width constants
+const COLUMN_WIDTHS = {
+  checkbox: 'w-[5%]',
+  beatmap: 'w-[10%]',
+  difficulty: 'w-[10%]',
+  sr: 'w-[8%]',
+  length: 'w-[8%]',
+  bpm: 'w-[8%]',
+  cs: 'w-[3%]',
+  ar: 'w-[3%]',
+  od: 'w-[3%]',
+  hp: 'w-[3%]',
+  mod: 'w-[5%]',
+  gameCount: 'w-[5%]',
+  creator: 'w-[7%]',
+} as const;
 
-export default function TournamentBeatmapsViewWithCheckboxes({
-  beatmaps,
-  tournamentGames = [],
-  onSelectBeatmap,
-}: TournamentBeatmapsViewWithCheckboxesProps) {
-  const [sortField, setSortField] = useState<SortField>('gameCount');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-
-  const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortField(field);
-      setSortDirection(field === 'sr' ? 'desc' : 'asc');
-    }
-  };
-
-  const sortedBeatmaps = useMemo(() => {
-    return [...beatmaps].sort((a, b) => {
-      let aValue: string | number;
-      let bValue: string | number;
-
-      switch (sortField) {
-        case 'title':
-          aValue = a.beatmapset?.title?.toLowerCase() || '';
-          bValue = b.beatmapset?.title?.toLowerCase() || '';
-          break;
-        case 'difficulty':
-          aValue = a.diffName?.toLowerCase() || '';
-          bValue = b.diffName?.toLowerCase() || '';
-          break;
-        case 'sr':
-          aValue = a.sr;
-          bValue = b.sr;
-          break;
-        case 'length':
-          aValue = a.totalLength;
-          bValue = b.totalLength;
-          break;
-        case 'bpm':
-          aValue = a.bpm || 0;
-          bValue = b.bpm || 0;
-          break;
-        case 'cs':
-          aValue = a.cs || 0;
-          bValue = b.cs || 0;
-          break;
-        case 'ar':
-          aValue = a.ar || 0;
-          bValue = b.ar || 0;
-          break;
-        case 'od':
-          aValue = a.od || 0;
-          bValue = b.od || 0;
-          break;
-        case 'hp':
-          aValue = a.hp || 0;
-          bValue = b.hp || 0;
-          break;
-        case 'mod':
-          {
-            const aModData = getMostCommonModForBeatmap(
-              a.osuId,
-              tournamentGames
-            );
-            const bModData = getMostCommonModForBeatmap(
-              b.osuId,
-              tournamentGames
-            );
-            aValue = aModData?.mod ?? -1;
-            bValue = bModData?.mod ?? -1;
-          }
-          break;
-        case 'gameCount':
-          {
-            const aModData = getMostCommonModForBeatmap(
-              a.osuId,
-              tournamentGames
-            );
-            const bModData = getMostCommonModForBeatmap(
-              b.osuId,
-              tournamentGames
-            );
-            aValue = aModData?.gameCount ?? 0;
-            bValue = bModData?.gameCount ?? 0;
-          }
-          break;
-        case 'creator':
-          aValue = a.beatmapset?.creator?.username?.toLowerCase() || '';
-          bValue = b.beatmapset?.creator?.username?.toLowerCase() || '';
-          break;
-        default:
-          return 0;
-      }
-
-      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-      return 0;
-    });
-  }, [beatmaps, sortField, sortDirection, tournamentGames]);
-
-  const SortButton = ({
+// Memoized SortButton component
+const SortButton = memo(
+  ({
     field,
     children,
+    sortField,
+    sortDirection,
+    onClick,
   }: {
     field: SortField;
     children: React.ReactNode;
+    sortField: SortField;
+    sortDirection: 'asc' | 'desc';
+    onClick: (field: SortField) => void;
   }) => (
     <button
-      onClick={() => handleSort(field)}
+      onClick={() => onClick(field)}
       className="flex items-center gap-1 transition-colors hover:text-foreground"
     >
       {children}
@@ -161,7 +76,182 @@ export default function TournamentBeatmapsViewWithCheckboxes({
           <ChevronDown className="h-3 w-3" />
         ))}
     </button>
-  );
+  )
+);
+SortButton.displayName = 'SortButton';
+
+// Memoized BeatmapRow component for better performance
+const BeatmapRow = memo(
+  ({
+    beatmap,
+    modData,
+    onSelectBeatmap,
+  }: {
+    beatmap: ExtendedBeatmapDTO;
+    modData: ReturnType<typeof getMostCommonModForBeatmap>;
+    onSelectBeatmap: (beatmapId: number, checked: boolean) => void;
+  }) => {
+    const handleCheckboxChange = useCallback(
+      (checked: boolean | 'indeterminate') => {
+        onSelectBeatmap(beatmap.id, checked as boolean);
+      },
+      [beatmap.id, onSelectBeatmap]
+    );
+
+    return (
+      <tr
+        className={`group transition-colors ${
+          beatmap.isDeleted
+            ? 'bg-destructive/5 hover:bg-destructive/10'
+            : 'hover:bg-muted/30'
+        }`}
+      >
+        {/* Checkbox */}
+        <td className="px-2 py-2 text-center">
+          <Checkbox
+            checked={beatmap.isSelected}
+            onCheckedChange={handleCheckboxChange}
+            aria-label={`Select ${beatmap.beatmapset?.title || 'beatmap'}`}
+          />
+        </td>
+
+        {/* Beatmap Info */}
+        <td className="px-2 py-2">
+          <div className="flex items-center gap-2">
+            {/* Thumbnail */}
+            <div className="relative h-10 w-16 flex-shrink-0 overflow-hidden rounded">
+              {beatmap.beatmapset?.osuId ? (
+                <BeatmapBackground
+                  beatmapsetId={beatmap.beatmapset?.osuId}
+                  alt={`${beatmap.beatmapset?.title} cover`}
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-muted">
+                  <Music className="h-3 w-3 text-muted-foreground" />
+                </div>
+              )}
+            </div>
+
+            {/* Song details */}
+            <div className="min-w-0 flex-1">
+              <Link
+                href={`https://osu.ppy.sh/b/${beatmap.osuId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block transition-colors hover:text-primary"
+              >
+                <p className="max-w-[160px] truncate text-xs font-medium">
+                  {beatmap.beatmapset?.title || 'Unknown Title'}
+                </p>
+                <p className="max-w-[140px] truncate text-xs text-muted-foreground">
+                  by {beatmap.beatmapset?.artist || 'Unknown Artist'}
+                </p>
+              </Link>
+            </div>
+          </div>
+        </td>
+
+        {/* Difficulty */}
+        <td className="px-2 py-2">
+          <span className="block max-w-[100px] truncate text-xs font-medium">
+            {beatmap.diffName || 'Unknown'}
+          </span>
+        </td>
+
+        {/* Star Rating */}
+        <td className="px-2 py-2 text-center">
+          <div className="flex items-center justify-center gap-1">
+            <Star className="h-3 w-3 fill-yellow-500 text-yellow-500" />
+            <span className="text-xs font-medium">{beatmap.sr.toFixed(2)}</span>
+          </div>
+        </td>
+
+        {/* Length */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">{formatDuration(beatmap.totalLength)}</span>
+        </td>
+
+        {/* BPM */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">
+            {beatmap.bpm ? Math.round(beatmap.bpm) : 'N/A'}
+          </span>
+        </td>
+
+        {/* CS */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">{beatmap.cs}</span>
+        </td>
+
+        {/* AR */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">{beatmap.ar}</span>
+        </td>
+
+        {/* OD */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">{beatmap.od}</span>
+        </td>
+
+        {/* HP */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs">
+            {beatmap.hp !== undefined ? beatmap.hp : 'N/A'}
+          </span>
+        </td>
+
+        {/* Most Common Mod */}
+        <td className="px-2 py-2 text-center">
+          <div className="flex items-center justify-center">
+            {modData ? (
+              <SingleModIcon mods={modData.mod} size={28} />
+            ) : (
+              <span className="text-xs text-muted-foreground">N/A</span>
+            )}
+          </div>
+        </td>
+
+        {/* Game Count */}
+        <td className="px-2 py-2 text-center">
+          <span className="text-xs font-medium">{modData?.gameCount ?? 0}</span>
+        </td>
+
+        {/* Creator */}
+        <td className="px-2 py-2 text-center">
+          <div className="flex items-center">
+            {beatmap.beatmapset?.creator ? (
+              <Link
+                href={`https://osu.ppy.sh/users/${beatmap.beatmapset.creator.osuId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex max-w-[120px] items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-primary"
+              >
+                <User className="h-3 w-3 flex-shrink-0" />
+                <span className="truncate">
+                  {beatmap.beatmapset.creator.username}
+                </span>
+              </Link>
+            ) : (
+              <span className="text-xs text-muted-foreground">Unknown</span>
+            )}
+          </div>
+        </td>
+      </tr>
+    );
+  }
+);
+BeatmapRow.displayName = 'BeatmapRow';
+
+export default function TournamentBeatmapsViewWithCheckboxes({
+  beatmaps,
+  tournamentGames = [],
+  onSelectBeatmap,
+}: TournamentBeatmapsViewWithCheckboxesProps) {
+  const { sortedBeatmaps, sortField, sortDirection, handleSort } =
+    useBeatmapSort({
+      beatmaps,
+      tournamentGames,
+    });
 
   if (beatmaps.length === 0) {
     return (
@@ -186,78 +276,178 @@ export default function TournamentBeatmapsViewWithCheckboxes({
             {/* Header */}
             <thead className="border-b bg-muted/50">
               <tr>
-                <th className="w-[5%] px-2 py-2">
+                <th className={`${COLUMN_WIDTHS.checkbox} px-2 py-2`}>
                   {/* Checkbox column header - empty */}
                 </th>
-                <th className="w-[10%] px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground">
-                  <SortButton field="title">Beatmap</SortButton>
+                <th
+                  className={`${COLUMN_WIDTHS.beatmap} px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground`}
+                >
+                  <SortButton
+                    field="title"
+                    sortField={sortField}
+                    sortDirection={sortDirection}
+                    onClick={handleSort}
+                  >
+                    Beatmap
+                  </SortButton>
                 </th>
-                <th className="w-[10%] px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground">
-                  <SortButton field="difficulty">Difficulty</SortButton>
+                <th
+                  className={`${COLUMN_WIDTHS.difficulty} px-2 py-2 text-left text-xs font-medium tracking-wider text-muted-foreground`}
+                >
+                  <SortButton
+                    field="difficulty"
+                    sortField={sortField}
+                    sortDirection={sortDirection}
+                    onClick={handleSort}
+                  >
+                    Difficulty
+                  </SortButton>
                 </th>
-                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.sr} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Star Rating">
                     <div className="flex justify-center">
-                      <SortButton field="sr">
+                      <SortButton
+                        field="sr"
+                        sortField={sortField}
+                        sortDirection={sortDirection}
+                        onClick={handleSort}
+                      >
                         <Star className="h-3 w-3" />
                       </SortButton>
                     </div>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.length} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Length">
                     <div className="flex justify-center">
-                      <SortButton field="length">
+                      <SortButton
+                        field="length"
+                        sortField={sortField}
+                        sortDirection={sortDirection}
+                        onClick={handleSort}
+                      >
                         <Clock className="h-3 w-3" />
                       </SortButton>
                     </div>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[8%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.bpm} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="BPM">
                     <div className="flex justify-center">
-                      <SortButton field="bpm">
+                      <SortButton
+                        field="bpm"
+                        sortField={sortField}
+                        sortDirection={sortDirection}
+                        onClick={handleSort}
+                      >
                         <Activity className="h-3 w-3" />
                       </SortButton>
                     </div>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.cs} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Circle Size">
-                    <SortButton field="cs">CS</SortButton>
+                    <SortButton
+                      field="cs"
+                      sortField={sortField}
+                      sortDirection={sortDirection}
+                      onClick={handleSort}
+                    >
+                      CS
+                    </SortButton>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.ar} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Approach Rate">
-                    <SortButton field="ar">AR</SortButton>
+                    <SortButton
+                      field="ar"
+                      sortField={sortField}
+                      sortDirection={sortDirection}
+                      onClick={handleSort}
+                    >
+                      AR
+                    </SortButton>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.od} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Overall Difficulty">
-                    <SortButton field="od">OD</SortButton>
+                    <SortButton
+                      field="od"
+                      sortField={sortField}
+                      sortDirection={sortDirection}
+                      onClick={handleSort}
+                    >
+                      OD
+                    </SortButton>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[3%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.hp} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="HP Drain Rate">
-                    <SortButton field="hp">HP</SortButton>
+                    <SortButton
+                      field="hp"
+                      sortField={sortField}
+                      sortDirection={sortDirection}
+                      onClick={handleSort}
+                    >
+                      HP
+                    </SortButton>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[5%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.mod} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Most Common Mod">
-                    <SortButton field="mod">Mod</SortButton>
+                    <SortButton
+                      field="mod"
+                      sortField={sortField}
+                      sortDirection={sortDirection}
+                      onClick={handleSort}
+                    >
+                      Mod
+                    </SortButton>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[5%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
+                <th
+                  className={`${COLUMN_WIDTHS.gameCount} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
                   <SimpleTooltip content="Number of Games">
                     <div className="flex justify-center">
-                      <SortButton field="gameCount">
+                      <SortButton
+                        field="gameCount"
+                        sortField={sortField}
+                        sortDirection={sortDirection}
+                        onClick={handleSort}
+                      >
                         <Gamepad2 className="h-3 w-3" />
                       </SortButton>
                     </div>
                   </SimpleTooltip>
                 </th>
-                <th className="w-[7%] px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground">
-                  <SortButton field="creator">Creator</SortButton>
+                <th
+                  className={`${COLUMN_WIDTHS.creator} px-2 py-2 text-center text-xs font-medium tracking-wider text-muted-foreground`}
+                >
+                  <SortButton
+                    field="creator"
+                    sortField={sortField}
+                    sortDirection={sortDirection}
+                    onClick={handleSort}
+                  >
+                    Creator
+                  </SortButton>
                 </th>
               </tr>
             </thead>
@@ -271,158 +461,12 @@ export default function TournamentBeatmapsViewWithCheckboxes({
                 );
 
                 return (
-                  <tr
+                  <BeatmapRow
                     key={beatmap.id}
-                    className={`group transition-colors ${
-                      beatmap.isDeleted
-                        ? 'bg-destructive/5 hover:bg-destructive/10'
-                        : 'hover:bg-muted/30'
-                    }`}
-                  >
-                    {/* Checkbox */}
-                    <td className="px-2 py-2 text-center">
-                      <Checkbox
-                        checked={beatmap.isSelected}
-                        onCheckedChange={(checked) =>
-                          onSelectBeatmap(beatmap.id, checked as boolean)
-                        }
-                        aria-label={`Select ${beatmap.beatmapset?.title || 'beatmap'}`}
-                      />
-                    </td>
-
-                    {/* Beatmap Info */}
-                    <td className="px-2 py-2">
-                      <div className="flex items-center gap-2">
-                        {/* Thumbnail */}
-                        <div className="relative h-10 w-16 flex-shrink-0 overflow-hidden rounded">
-                          {beatmap.beatmapset?.osuId ? (
-                            <BeatmapBackground
-                              beatmapsetId={beatmap.beatmapset?.osuId}
-                              alt={`${beatmap.beatmapset?.title} cover`}
-                            />
-                          ) : (
-                            <div className="flex h-full w-full items-center justify-center bg-muted">
-                              <Music className="h-3 w-3 text-muted-foreground" />
-                            </div>
-                          )}
-                        </div>
-
-                        {/* Song details */}
-                        <div className="min-w-0 flex-1">
-                          <Link
-                            href={`https://osu.ppy.sh/b/${beatmap.osuId}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="block transition-colors hover:text-primary"
-                          >
-                            <p className="max-w-[160px] truncate text-xs font-medium">
-                              {beatmap.beatmapset?.title || 'Unknown Title'}
-                            </p>
-                            <p className="max-w-[140px] truncate text-xs text-muted-foreground">
-                              by{' '}
-                              {beatmap.beatmapset?.artist || 'Unknown Artist'}
-                            </p>
-                          </Link>
-                        </div>
-                      </div>
-                    </td>
-
-                    {/* Difficulty */}
-                    <td className="px-2 py-2">
-                      <span className="block max-w-[100px] truncate text-xs font-medium">
-                        {beatmap.diffName || 'Unknown'}
-                      </span>
-                    </td>
-
-                    {/* Star Rating */}
-                    <td className="px-2 py-2 text-center">
-                      <div className="flex items-center justify-center gap-1">
-                        <Star className="h-3 w-3 fill-yellow-500 text-yellow-500" />
-                        <span className="text-xs font-medium">
-                          {beatmap.sr.toFixed(2)}
-                        </span>
-                      </div>
-                    </td>
-
-                    {/* Length */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">
-                        {formatDuration(beatmap.totalLength)}
-                      </span>
-                    </td>
-
-                    {/* BPM */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">
-                        {beatmap.bpm ? Math.round(beatmap.bpm) : 'N/A'}
-                      </span>
-                    </td>
-
-                    {/* CS */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">{beatmap.cs}</span>
-                    </td>
-
-                    {/* AR */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">{beatmap.ar}</span>
-                    </td>
-
-                    {/* OD */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">{beatmap.od}</span>
-                    </td>
-
-                    {/* HP */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs">
-                        {beatmap.hp !== undefined ? beatmap.hp : 'N/A'}
-                      </span>
-                    </td>
-
-                    {/* Most Common Mod */}
-                    <td className="px-2 py-2 text-center">
-                      <div className="flex items-center justify-center">
-                        {modData ? (
-                          <SingleModIcon mods={modData.mod} size={28} />
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            N/A
-                          </span>
-                        )}
-                      </div>
-                    </td>
-
-                    {/* Game Count */}
-                    <td className="px-2 py-2 text-center">
-                      <span className="text-xs font-medium">
-                        {modData?.gameCount ?? 0}
-                      </span>
-                    </td>
-
-                    {/* Creator */}
-                    <td className="px-2 py-2 text-center">
-                      <div className="flex items-center">
-                        {beatmap.beatmapset?.creator ? (
-                          <Link
-                            href={`https://osu.ppy.sh/users/${beatmap.beatmapset.creator.osuId}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex max-w-[120px] items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-primary"
-                          >
-                            <User className="h-3 w-3 flex-shrink-0" />
-                            <span className="truncate">
-                              {beatmap.beatmapset.creator.username}
-                            </span>
-                          </Link>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            Unknown
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
+                    beatmap={beatmap}
+                    modData={modData}
+                    onSelectBeatmap={onSelectBeatmap}
+                  />
                 );
               })}
             </tbody>

--- a/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
+++ b/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
@@ -21,7 +21,7 @@ import BeatmapBackground from '../games/BeatmapBackground';
 import { Checkbox } from '@/components/ui/checkbox';
 
 interface TournamentBeatmapsViewWithCheckboxesProps {
-  beatmaps: (BeatmapDTO & { isSelected: boolean })[];
+  beatmaps: (BeatmapDTO & { isSelected: boolean; isDeleted?: boolean })[];
   tournamentGames?: GameDTO[];
   onSelectBeatmap: (beatmapId: number, checked: boolean) => void;
 }
@@ -59,93 +59,87 @@ export default function TournamentBeatmapsViewWithCheckboxes({
   };
 
   const sortedBeatmaps = useMemo(() => {
-    return [...beatmaps]
-      .filter((beatmap) => {
-        const artist = beatmap.beatmapset?.artist || 'Unknown Artist';
-        const title = beatmap.beatmapset?.title || 'Unknown Title';
-        return !(artist === 'Unknown Artist' && title === 'Unknown Title');
-      })
-      .sort((a, b) => {
-        let aValue: string | number;
-        let bValue: string | number;
+    return [...beatmaps].sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
 
-        switch (sortField) {
-          case 'title':
-            aValue = a.beatmapset?.title?.toLowerCase() || '';
-            bValue = b.beatmapset?.title?.toLowerCase() || '';
-            break;
-          case 'difficulty':
-            aValue = a.diffName?.toLowerCase() || '';
-            bValue = b.diffName?.toLowerCase() || '';
-            break;
-          case 'sr':
-            aValue = a.sr;
-            bValue = b.sr;
-            break;
-          case 'length':
-            aValue = a.totalLength;
-            bValue = b.totalLength;
-            break;
-          case 'bpm':
-            aValue = a.bpm || 0;
-            bValue = b.bpm || 0;
-            break;
-          case 'cs':
-            aValue = a.cs || 0;
-            bValue = b.cs || 0;
-            break;
-          case 'ar':
-            aValue = a.ar || 0;
-            bValue = b.ar || 0;
-            break;
-          case 'od':
-            aValue = a.od || 0;
-            bValue = b.od || 0;
-            break;
-          case 'hp':
-            aValue = a.hp || 0;
-            bValue = b.hp || 0;
-            break;
-          case 'mod':
-            {
-              const aModData = getMostCommonModForBeatmap(
-                a.osuId,
-                tournamentGames
-              );
-              const bModData = getMostCommonModForBeatmap(
-                b.osuId,
-                tournamentGames
-              );
-              aValue = aModData?.mod ?? -1;
-              bValue = bModData?.mod ?? -1;
-            }
-            break;
-          case 'gameCount':
-            {
-              const aModData = getMostCommonModForBeatmap(
-                a.osuId,
-                tournamentGames
-              );
-              const bModData = getMostCommonModForBeatmap(
-                b.osuId,
-                tournamentGames
-              );
-              aValue = aModData?.gameCount ?? 0;
-              bValue = bModData?.gameCount ?? 0;
-            }
-            break;
-          case 'creator':
-            aValue = a.beatmapset?.creator?.username?.toLowerCase() || '';
-            bValue = b.beatmapset?.creator?.username?.toLowerCase() || '';
-            break;
-          default:
-            return 0;
-        }
+      switch (sortField) {
+        case 'title':
+          aValue = a.beatmapset?.title?.toLowerCase() || '';
+          bValue = b.beatmapset?.title?.toLowerCase() || '';
+          break;
+        case 'difficulty':
+          aValue = a.diffName?.toLowerCase() || '';
+          bValue = b.diffName?.toLowerCase() || '';
+          break;
+        case 'sr':
+          aValue = a.sr;
+          bValue = b.sr;
+          break;
+        case 'length':
+          aValue = a.totalLength;
+          bValue = b.totalLength;
+          break;
+        case 'bpm':
+          aValue = a.bpm || 0;
+          bValue = b.bpm || 0;
+          break;
+        case 'cs':
+          aValue = a.cs || 0;
+          bValue = b.cs || 0;
+          break;
+        case 'ar':
+          aValue = a.ar || 0;
+          bValue = b.ar || 0;
+          break;
+        case 'od':
+          aValue = a.od || 0;
+          bValue = b.od || 0;
+          break;
+        case 'hp':
+          aValue = a.hp || 0;
+          bValue = b.hp || 0;
+          break;
+        case 'mod':
+          {
+            const aModData = getMostCommonModForBeatmap(
+              a.osuId,
+              tournamentGames
+            );
+            const bModData = getMostCommonModForBeatmap(
+              b.osuId,
+              tournamentGames
+            );
+            aValue = aModData?.mod ?? -1;
+            bValue = bModData?.mod ?? -1;
+          }
+          break;
+        case 'gameCount':
+          {
+            const aModData = getMostCommonModForBeatmap(
+              a.osuId,
+              tournamentGames
+            );
+            const bModData = getMostCommonModForBeatmap(
+              b.osuId,
+              tournamentGames
+            );
+            aValue = aModData?.gameCount ?? 0;
+            bValue = bModData?.gameCount ?? 0;
+          }
+          break;
+        case 'creator':
+          aValue = a.beatmapset?.creator?.username?.toLowerCase() || '';
+          bValue = b.beatmapset?.creator?.username?.toLowerCase() || '';
+          break;
+        default:
+          return 0;
+      }
 
-        if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-        if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-        return 0;
-      });
+      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
   }, [beatmaps, sortField, sortDirection, tournamentGames]);
 
   const SortButton = ({
@@ -279,7 +273,11 @@ export default function TournamentBeatmapsViewWithCheckboxes({
                 return (
                   <tr
                     key={beatmap.id}
-                    className="group transition-colors hover:bg-muted/30"
+                    className={`group transition-colors ${
+                      beatmap.isDeleted
+                        ? 'bg-destructive/5 hover:bg-destructive/10'
+                        : 'hover:bg-muted/30'
+                    }`}
                   >
                     {/* Checkbox */}
                     <td className="px-2 py-2 text-center">

--- a/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
+++ b/components/tournaments/TournamentBeatmapsViewWithCheckboxes.tsx
@@ -32,7 +32,6 @@ interface TournamentBeatmapsViewWithCheckboxesProps {
   onSelectBeatmap: (beatmapId: number, checked: boolean) => void;
 }
 
-// Table column width constants
 const COLUMN_WIDTHS = {
   checkbox: 'w-[5%]',
   beatmap: 'w-[10%]',
@@ -49,7 +48,6 @@ const COLUMN_WIDTHS = {
   creator: 'w-[7%]',
 } as const;
 
-// Memoized SortButton component
 const SortButton = memo(
   ({
     field,
@@ -80,7 +78,6 @@ const SortButton = memo(
 );
 SortButton.displayName = 'SortButton';
 
-// Memoized BeatmapRow component for better performance
 const BeatmapRow = memo(
   ({
     beatmap,

--- a/lib/actions/tournaments.ts
+++ b/lib/actions/tournaments.ts
@@ -96,3 +96,11 @@ export async function getBeatmaps(id: number) {
 export async function deleteBeatmaps(id: number) {
   await tournaments.deleteBeatmaps({ id });
 }
+
+export async function insertBeatmaps(id: number, beatmapIds: number[]) {
+  await tournaments.insertBeatmaps({ id, body: beatmapIds });
+}
+
+export async function deleteSpecificBeatmaps(id: number, beatmapIds: number[]) {
+  await tournaments.deleteBeatmaps({ id, body: beatmapIds });
+}

--- a/lib/hooks/useBeatmapSort.ts
+++ b/lib/hooks/useBeatmapSort.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { BeatmapDTO, GameDTO } from '@osu-tournament-rating/otr-api-client';
+import { getMostCommonModForBeatmap } from '@/lib/utils/mods';
+
+export type SortField =
+  | 'title'
+  | 'difficulty'
+  | 'sr'
+  | 'length'
+  | 'bpm'
+  | 'cs'
+  | 'ar'
+  | 'od'
+  | 'hp'
+  | 'mod'
+  | 'gameCount'
+  | 'creator';
+
+export type SortDirection = 'asc' | 'desc';
+
+interface UseBeatmapSortOptions<T extends BeatmapDTO> {
+  beatmaps: T[];
+  tournamentGames?: GameDTO[];
+  initialSort?: SortField;
+  initialDirection?: SortDirection;
+}
+
+interface UseBeatmapSortReturn<T extends BeatmapDTO> {
+  sortedBeatmaps: T[];
+  sortField: SortField;
+  sortDirection: SortDirection;
+  handleSort: (field: SortField) => void;
+}
+
+const getSortValue = (
+  beatmap: BeatmapDTO,
+  field: SortField,
+  tournamentGames: GameDTO[] = []
+): string | number => {
+  switch (field) {
+    case 'title':
+      return beatmap.beatmapset?.title?.toLowerCase() || '';
+    case 'difficulty':
+      return beatmap.diffName?.toLowerCase() || '';
+    case 'sr':
+      return beatmap.sr;
+    case 'length':
+      return beatmap.totalLength;
+    case 'bpm':
+      return beatmap.bpm || 0;
+    case 'cs':
+      return beatmap.cs || 0;
+    case 'ar':
+      return beatmap.ar || 0;
+    case 'od':
+      return beatmap.od || 0;
+    case 'hp':
+      return beatmap.hp || 0;
+    case 'mod': {
+      const modData = getMostCommonModForBeatmap(
+        beatmap.osuId,
+        tournamentGames
+      );
+      return modData?.mod ?? -1;
+    }
+    case 'gameCount': {
+      const modData = getMostCommonModForBeatmap(
+        beatmap.osuId,
+        tournamentGames
+      );
+      return modData?.gameCount ?? 0;
+    }
+    case 'creator':
+      return beatmap.beatmapset?.creator?.username?.toLowerCase() || '';
+    default:
+      return 0;
+  }
+};
+
+export function useBeatmapSort<T extends BeatmapDTO>({
+  beatmaps,
+  tournamentGames = [],
+  initialSort = 'gameCount',
+  initialDirection = 'desc',
+}: UseBeatmapSortOptions<T>): UseBeatmapSortReturn<T> {
+  const [sortField, setSortField] = useState<SortField>(initialSort);
+  const [sortDirection, setSortDirection] =
+    useState<SortDirection>(initialDirection);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      // Default to descending for star rating, ascending for others
+      setSortDirection(
+        field === 'sr' || field === 'gameCount' ? 'desc' : 'asc'
+      );
+    }
+  };
+
+  const sortedBeatmaps = useMemo(() => {
+    return [...beatmaps].sort((a, b) => {
+      const aValue = getSortValue(a, sortField, tournamentGames);
+      const bValue = getSortValue(b, sortField, tournamentGames);
+
+      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [beatmaps, sortField, sortDirection, tournamentGames]);
+
+  return {
+    sortedBeatmaps,
+    sortField,
+    sortDirection,
+    handleSort,
+  };
+}


### PR DESCRIPTION
Allows admins to modify a tournament's pooled beatmaps collection. Closes #372 