### PR TITLE
fix: Tournament start date formatting

### DIFF
--- a/app/tournaments/[id]/columns.tsx
+++ b/app/tournaments/[id]/columns.tsx
@@ -11,6 +11,7 @@ import { createColumnHelper } from '@tanstack/react-table';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import { formatUTCDateFull } from '@/lib/utils/date';
 
 export type MatchRow = {
   id: number;
@@ -197,7 +198,7 @@ export const columns = [
     },
     cell: ({ getValue }) => (
       <span className="hidden md:inline">
-        {new Date(getValue()).toLocaleString()}
+        {formatUTCDateFull(new Date(getValue()))}
       </span>
     ),
     sortingFn: (rowA, rowB) => {


### PR DESCRIPTION
- Updates the Start Date column to use this format: 2024-09-07 15:02:44 UTC (was '9/7/2024, 11:02:44 AM')

<img width="1239" height="651" alt="image" src="https://github.com/user-attachments/assets/22124c7c-0b64-46af-b88c-eff70f39df15" />

Closes #442
