### PR TITLE
fix: extend deploy timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: ${{ inputs.target }}
 
     steps:


### PR DESCRIPTION
For long-running migrations this is required, otherwise the workflow gets aborted after 10mins.