### PR TITLE
Add "Pooled Beatmaps" card to player page

### DIFF
--- a/apps/web/app/server/oRPC/procedures/playerProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/playerProcedures.ts
@@ -411,7 +411,6 @@ export const getPlayerBeatmaps = publicProcedure
   .handler(async ({ input, context }) => {
     const player = await findPlayerByKey(context.db, input.key);
 
-    // goofy ahh lil sql query
     const beatmapRows = await context.db
       .select({
         id: schema.beatmaps.id,

--- a/apps/web/app/server/oRPC/procedures/playerProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/playerProcedures.ts
@@ -522,8 +522,49 @@ export const getPlayerBeatmaps = publicProcedure
       )
       .orderBy(desc(schema.tournaments.endTime));
 
+    interface BeatmapData {
+      id: number;
+      osuId: number;
+      rankedStatus: number;
+      diffName: string;
+      totalLength: number;
+      drainLength: number;
+      bpm: number;
+      countCircle: number;
+      countSlider: number;
+      countSpinner: number;
+      cs: number;
+      hp: number;
+      od: number;
+      ar: number;
+      sr: number;
+      maxCombo: number | null;
+      beatmapsetId: number;
+      ruleset: number;
+      artist: string;
+      title: string;
+      tournamentCount: number;
+      gameCount: number;
+      tournaments: Array<{
+        id: number;
+        created: string;
+        name: string;
+        abbreviation: string;
+        forumUrl: string;
+        rankRangeLowerBound: number;
+        ruleset: number;
+        lobbySize: number;
+        startTime: string | null;
+        endTime: string | null;
+        verificationStatus: number;
+        rejectionReason: number;
+        gamesPlayed: number;
+        mostCommonMod: number;
+      }>;
+    }
+
     // Map of beatmap ID to aggregated data
-    const beatmapsMap = new Map<number, any>();
+    const beatmapsMap = new Map<number, BeatmapData>();
 
     // Iterate over rows to count tournaments / mod usage
     for (const row of beatmapRows) {
@@ -556,6 +597,11 @@ export const getPlayerBeatmaps = publicProcedure
       }
 
       const beatmap = beatmapsMap.get(row.id);
+      if (!beatmap) {
+        continue;
+      }
+
+      // Update tournament and game counts
       beatmap.tournamentCount++;
       beatmap.gameCount += Number(row.gamesPlayed);
 
@@ -584,22 +630,24 @@ export const getPlayerBeatmaps = publicProcedure
       }
 
       // Append tournament info
-      beatmap.tournaments.push({
-        id: row.tournamentId,
-        created: row.tournamentCreated,
-        name: row.tournamentName,
-        abbreviation: row.tournamentAbbreviation,
-        forumUrl: row.tournamentForumUrl,
-        rankRangeLowerBound: row.tournamentRankRangeLowerBound,
-        ruleset: row.tournamentRuleset,
-        lobbySize: row.tournamentLobbySize,
-        startTime: row.tournamentStartTime,
-        endTime: row.tournamentEndTime,
-        verificationStatus: row.tournamentVerificationStatus,
-        rejectionReason: row.tournamentRejectionReason,
-        gamesPlayed: Number(row.gamesPlayed),
-        mostCommonMod: Number(mostCommonMod),
-      });
+      if (beatmap) {
+        beatmap.tournaments.push({
+          id: row.tournamentId,
+          created: row.tournamentCreated,
+          name: row.tournamentName,
+          abbreviation: row.tournamentAbbreviation,
+          forumUrl: row.tournamentForumUrl,
+          rankRangeLowerBound: row.tournamentRankRangeLowerBound,
+          ruleset: row.tournamentRuleset,
+          lobbySize: row.tournamentLobbySize,
+          startTime: row.tournamentStartTime,
+          endTime: row.tournamentEndTime,
+          verificationStatus: row.tournamentVerificationStatus,
+          rejectionReason: row.tournamentRejectionReason,
+          gamesPlayed: Number(row.gamesPlayed),
+          mostCommonMod: Number(mostCommonMod),
+        });
+      }
     }
 
     // Convert to array and sort by tournament count, game count, and beatmap ID

--- a/apps/web/app/server/oRPC/router.ts
+++ b/apps/web/app/server/oRPC/router.ts
@@ -20,6 +20,7 @@ import {
 } from './procedures/scores/adminProcedures';
 import {
   getPlayer,
+  getPlayerBeatmaps,
   getPlayerDashboardStats,
   getPlayerTournaments,
 } from './procedures/playerProcedures';
@@ -118,6 +119,7 @@ export const router = base.router({
   },
   players: {
     get: getPlayer,
+    beatmaps: getPlayerBeatmaps,
     dashboard: getPlayerDashboardStats,
     tournaments: getPlayerTournaments,
   },

--- a/apps/web/components/games/BeatmapBackground.tsx
+++ b/apps/web/components/games/BeatmapBackground.tsx
@@ -2,15 +2,18 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
+import { cn } from '@/lib/utils';
 
 interface BeatmapBackgroundProps {
   beatmapsetId?: number;
   alt: string;
+  className?: string;
 }
 
 export default function BeatmapBackground({
   beatmapsetId,
   alt,
+  className,
 }: BeatmapBackgroundProps) {
   const [hasError, setHasError] = useState(false);
 
@@ -23,7 +26,7 @@ export default function BeatmapBackground({
 
   return (
     <Image
-      className="z-1 absolute rounded-xl object-cover"
+      className={cn('z-1 absolute object-cover', 'rounded-xl', className)}
       src={hasError ? fallbackSrc : beatmapSrc}
       alt={alt}
       fill

--- a/apps/web/components/icons/ModIconset.tsx
+++ b/apps/web/components/icons/ModIconset.tsx
@@ -8,11 +8,13 @@ export default function ModIconset({
   className,
   iconClassName,
   freemod = false,
+  alwaysExpanded = false,
 }: {
   mods: Mods;
   className?: string;
   iconClassName?: string;
   freemod?: boolean;
+  alwaysExpanded?: boolean;
 }) {
   // Clear NF
   mods &= ~Mods.NoFail;
@@ -29,7 +31,10 @@ export default function ModIconset({
         <div
           key={mod}
           className={cn(
-            `not-first:-ml-4 peer-hover:not-first:-ml-2 hover:not-first:-ml-2 peer relative aspect-[60/45] h-full max-h-12 transition-[margin] duration-200 ease-in-out`,
+            'peer relative aspect-[60/45] h-full max-h-12 transition-[margin] duration-200 ease-in-out',
+            alwaysExpanded
+              ? 'not-first:-ml-2'
+              : 'not-first:-ml-4 peer-hover:not-first:-ml-2 hover:not-first:-ml-2',
             iconClassName
           )}
           style={{ zIndex: idx }}

--- a/apps/web/components/player/PlayerBeatmapCard.tsx
+++ b/apps/web/components/player/PlayerBeatmapCard.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { RulesetEnumHelper } from '@/lib/enums';
+import Link from 'next/link';
+import { Card } from '../ui/card';
+import RulesetIcon from '../icons/RulesetIcon';
+import {
+  Timer,
+  Music,
+  Star,
+  Trophy,
+  ChevronDown,
+  ChevronUp,
+  Gamepad2,
+} from 'lucide-react';
+import { PlayerBeatmapStats } from '@/lib/orpc/schema/playerBeatmaps';
+import BeatmapBackground from '../games/BeatmapBackground';
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import PlayerBeatmapTournamentTable from './PlayerBeatmapTournamentTable';
+import { cn } from '@/lib/utils';
+
+interface PlayerBeatmapCardProps {
+  beatmap: PlayerBeatmapStats;
+}
+
+export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
+  const [showTournaments, setShowTournaments] = useState(false);
+  const minutes = Math.floor(beatmap.totalLength / 60);
+  const seconds = beatmap.totalLength % 60;
+  const duration = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+
+  const totalGamesPlayed = beatmap.tournaments.reduce(
+    (sum, tournament) => sum + tournament.gamesPlayed,
+    0
+  );
+
+  const cardContent = (
+    <div className="relative overflow-hidden">
+      <BeatmapBackground
+        beatmapsetId={beatmap.beatmapsetId ?? undefined}
+        alt={`Beatmap ${beatmap.osuId} background`}
+        className={cn(showTournaments && 'rounded-b-none')}
+      />
+
+      {/* Gradient overlay for better text contrast */}
+      <div className="absolute inset-0 z-[2] h-full w-full bg-gradient-to-b from-black/60 via-black/50 to-black/60" />
+
+      <div className="relative z-[3] flex flex-col gap-3 p-4 sm:p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex w-full items-center gap-2 sm:w-auto">
+            <span className="font-mono text-sm text-white/80">
+              /b/{beatmap.osuId}
+            </span>
+          </div>
+          <div className="flex items-center gap-3 text-sm text-white/90">
+            <div className="flex items-center gap-1.5">
+              <span>{beatmap.tournamentCount}</span>
+              <Trophy className="h-4 w-4 flex-shrink-0" />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span>{totalGamesPlayed}</span>
+              <Gamepad2 className="h-4 w-4 flex-shrink-0" />
+            </div>
+          </div>
+        </div>
+
+        <Link
+          href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}
+          target="_blank"
+          className="group/link"
+        >
+          <h2 className="text-lg font-semibold leading-tight text-white drop-shadow-sm group-hover/link:underline sm:text-xl md:text-2xl">
+            {beatmap.artist} - {beatmap.title}
+          </h2>
+          <div className="mt-1 text-sm text-white/80">[{beatmap.diffName}]</div>
+        </Link>
+
+        <div className="flex flex-col gap-2 text-sm text-white/80 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+            <div className="flex items-center gap-1.5">
+              <RulesetIcon
+                ruleset={beatmap.ruleset}
+                width={16}
+                height={16}
+                className="flex-shrink-0 fill-white"
+              />
+              <span className="truncate">
+                {RulesetEnumHelper.getMetadata(beatmap.ruleset).text}
+              </span>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <Star className="h-4 w-4 flex-shrink-0" />
+              <span>{beatmap.sr.toFixed(2)}★</span>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <Timer className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">{duration}</span>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <Music className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">{beatmap.bpm.toFixed(0)} BPM</span>
+            </div>
+          </div>
+
+          <Button
+            onClick={() => setShowTournaments(!showTournaments)}
+            variant="outline"
+            className={cn(
+              '-my-1 h-8 gap-2 px-3 text-sm',
+              'hover:bg-accent hover:text-accent-foreground',
+              'border-input text-foreground border',
+              showTournaments && 'bg-accent text-accent-foreground'
+            )}
+          >
+            {showTournaments ? 'Hide Tournaments' : 'Show Tournaments'}
+            {showTournaments ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col">
+      <Card
+        className={cn(
+          'relative overflow-hidden p-0 font-sans',
+          showTournaments && 'rounded-b-none'
+        )}
+      >
+        {cardContent}
+      </Card>
+      {showTournaments && (
+        <Card className="rounded-t-none border-t-0 p-4 sm:p-6">
+          <PlayerBeatmapTournamentTable tournaments={beatmap.tournaments} />
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/player/PlayerBeatmapCard.tsx
+++ b/apps/web/components/player/PlayerBeatmapCard.tsx
@@ -5,13 +5,13 @@ import Link from 'next/link';
 import { Card } from '../ui/card';
 import RulesetIcon from '../icons/RulesetIcon';
 import {
-  Timer,
+  Eye,
+  EyeOff,
+  Gamepad2,
   Music,
   Star,
+  Timer,
   Trophy,
-  ChevronDown,
-  ChevronUp,
-  Gamepad2,
 } from 'lucide-react';
 import { PlayerBeatmapStats } from '@/lib/orpc/schema/playerBeatmaps';
 import BeatmapBackground from '../games/BeatmapBackground';
@@ -116,12 +116,12 @@ export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
               showTournaments && 'bg-accent text-accent-foreground'
             )}
           >
-            {showTournaments ? 'Hide Tournaments' : 'Show Tournaments'}
             {showTournaments ? (
-              <ChevronUp className="h-4 w-4" />
+              <EyeOff className="h-4 w-4" />
             ) : (
-              <ChevronDown className="h-4 w-4" />
+              <Eye className="h-4 w-4" />
             )}
+            Tournaments
           </Button>
         </div>
       </div>

--- a/apps/web/components/player/PlayerBeatmapCard.tsx
+++ b/apps/web/components/player/PlayerBeatmapCard.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react';
 import { Button } from '../ui/button';
 import PlayerBeatmapTournamentTable from './PlayerBeatmapTournamentTable';
 import { cn } from '@/lib/utils';
+import { formatSecondsToMinutesSeconds } from '@otr/core/utils/time';
 
 interface PlayerBeatmapCardProps {
   beatmap: PlayerBeatmapStats;
@@ -26,9 +27,7 @@ interface PlayerBeatmapCardProps {
 
 export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
   const [showTournaments, setShowTournaments] = useState(false);
-  const minutes = Math.floor(beatmap.totalLength / 60);
-  const seconds = beatmap.totalLength % 60;
-  const duration = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  const duration = formatSecondsToMinutesSeconds(beatmap.totalLength);
 
   const totalGamesPlayed = beatmap.tournaments.reduce(
     (sum, tournament) => sum + tournament.gamesPlayed,

--- a/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
+++ b/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import Link from 'next/link';
+import { formatUTCDate } from '@/lib/utils/date';
+import { formatRankRange } from '@/lib/utils/number';
+import VerificationBadge from '@/components/badges/VerificationBadge';
+import { Calendar, Target, Users, Gamepad2, CirclePlus } from 'lucide-react';
+import ModIconset from '../icons/ModIconset';
+import { BeatmapTournamentListItem } from '@/lib/orpc/schema/playerBeatmaps';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import SimpleTooltip from '../simple-tooltip';
+import { Mods } from '@otr/core/osu';
+
+interface PlayerBeatmapTournamentTableProps {
+  tournaments: BeatmapTournamentListItem[];
+}
+
+function formatRankRangeDisplay(rankRange: number): string {
+  if (rankRange === 1) return 'Open';
+  return formatRankRange(rankRange);
+}
+
+export default function PlayerBeatmapTournamentTable({
+  tournaments,
+}: PlayerBeatmapTournamentTableProps) {
+  return (
+    <div className="overflow-hidden">
+      <div className="overflow-x-auto">
+        <TooltipProvider>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="bg-muted/50 w-[40px]" />
+                <TableHead className="bg-muted/50 text-left">
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Calendar className="mx-auto h-4 w-4" />
+                    </TooltipTrigger>
+                    <TooltipContent>Date Range</TooltipContent>
+                  </Tooltip>
+                </TableHead>
+                <TableHead className="bg-muted/50">Tournament</TableHead>
+                <TableHead className="bg-muted/50 text-center">
+                  <SimpleTooltip content="Rank Range">
+                    <Target className="mx-auto h-4 w-4" />
+                  </SimpleTooltip>
+                </TableHead>
+                <TableHead className="bg-muted/50 text-center">
+                  <SimpleTooltip content="Team Size">
+                    <Users className="mx-auto h-4 w-4" />
+                  </SimpleTooltip>
+                </TableHead>
+                <TableHead className="bg-muted/50 text-center">
+                  <SimpleTooltip content="Mod">
+                    <CirclePlus className="mx-auto h-4 w-4" />
+                  </SimpleTooltip>
+                </TableHead>
+                <TableHead className="bg-muted/50 text-center">
+                  <SimpleTooltip content="Number of Games">
+                    <Gamepad2 className="mx-auto h-4 w-4" />
+                  </SimpleTooltip>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {tournaments.length > 0 ? (
+                tournaments.map((tournament) => {
+                  const startDate = tournament.startTime
+                    ? new Date(tournament.startTime)
+                    : null;
+                  const endDate = tournament.endTime
+                    ? new Date(tournament.endTime)
+                    : null;
+
+                  return (
+                    <TableRow
+                      key={tournament.id}
+                      className="hover:bg-muted/30 transition-colors duration-200"
+                    >
+                      <TableCell className="w-[40px] py-2">
+                        <VerificationBadge
+                          verificationStatus={tournament.verificationStatus}
+                          rejectionReason={tournament.rejectionReason}
+                          entityType="tournament"
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell className="text-muted-foreground py-2 text-sm">
+                        {startDate && endDate && (
+                          <span className="whitespace-nowrap">
+                            {formatUTCDate(startDate)} -{' '}
+                            {formatUTCDate(endDate)}
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="py-2">
+                        <Link
+                          href={`/tournaments/${tournament.id}`}
+                          className="hover:underline"
+                        >
+                          {tournament.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground py-2 text-sm">
+                        <div className="text-center">
+                          {formatRankRangeDisplay(
+                            tournament.rankRangeLowerBound
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground w-[80px] whitespace-nowrap py-2 text-sm">
+                        <div className="text-center">
+                          {tournament.lobbySize}v{tournament.lobbySize}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground py-2">
+                        <div className="flex h-7 items-center justify-center">
+                          {tournament.mostCommonMod === Mods.None ? (
+                            <span>N/A</span>
+                          ) : (
+                            <ModIconset
+                              mods={tournament.mostCommonMod ?? Mods.None}
+                              className="flex h-full items-center"
+                              iconClassName="h-7"
+                              alwaysExpanded={true}
+                            />
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground py-2 text-sm">
+                        <div className="text-center">
+                          {tournament.gamesPlayed ?? 0}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={7}
+                    className="text-muted-foreground h-24 text-center"
+                  >
+                    No tournament data available
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/player/PlayerBeatmapsList.tsx
+++ b/apps/web/components/player/PlayerBeatmapsList.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Music } from 'lucide-react';
+import { useState } from 'react';
+import PlayerBeatmapCard from './PlayerBeatmapCard';
+import { PlayerBeatmapStats } from '@/lib/orpc/schema/playerBeatmaps';
+
+interface PlayerBeatmapsListProps {
+  beatmaps: PlayerBeatmapStats[];
+}
+
+export default function PlayerBeatmapsList({
+  beatmaps,
+}: PlayerBeatmapsListProps) {
+  const NUM_INITIAL_DISPLAY = 3;
+  const NUM_LOAD_MORE = 100;
+  const [displayCount, setDisplayCount] = useState(NUM_INITIAL_DISPLAY);
+
+  // Get beatmaps up to the current display count
+  const displayedBeatmaps = beatmaps.slice(0, displayCount);
+
+  if (beatmaps.length === 0) {
+    return <NoResultsCard />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-row items-center gap-2">
+          <Music className="text-primary h-6 w-6" />
+          <CardTitle className="text-xl font-bold">Pooled Beatmaps</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col space-y-4">
+        {displayedBeatmaps.map((beatmap) => (
+          <PlayerBeatmapCard key={beatmap.id} beatmap={beatmap} />
+        ))}
+        {beatmaps.length > displayCount && (
+          <Button
+            variant="outline"
+            className="w-full justify-center"
+            onClick={() =>
+              setDisplayCount((prev) =>
+                Math.min(prev + NUM_LOAD_MORE, beatmaps.length)
+              )
+            }
+          >
+            Show More ({beatmaps.length - displayCount} more)
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function NoResultsCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-row items-center gap-2">
+          <Music className="text-primary h-6 w-6" />
+          <CardTitle className="text-xl font-bold">Pooled Beatmaps</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col space-y-4">
+        <Card className="w-full gap-2 p-6 text-center">
+          <h2 className="text-xl font-semibold">No Beatmaps Found</h2>
+          <p className="text-muted-foreground">
+            This player has no pooled beatmaps for the selected ruleset.
+          </p>
+        </Card>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/player/PlayerBeatmapsList.tsx
+++ b/apps/web/components/player/PlayerBeatmapsList.tsx
@@ -15,7 +15,7 @@ export default function PlayerBeatmapsList({
   beatmaps,
 }: PlayerBeatmapsListProps) {
   const NUM_INITIAL_DISPLAY = 3;
-  const NUM_LOAD_MORE = 100;
+  const NUM_LOAD_MORE = 25;
   const [displayCount, setDisplayCount] = useState(NUM_INITIAL_DISPLAY);
 
   // Get beatmaps up to the current display count
@@ -42,8 +42,8 @@ export default function PlayerBeatmapsList({
             variant="outline"
             className="w-full justify-center"
             onClick={() =>
-              setDisplayCount((prev) =>
-                Math.min(prev + NUM_LOAD_MORE, beatmaps.length)
+              setDisplayCount(
+                Math.min(displayCount + NUM_LOAD_MORE, beatmaps.length)
               )
             }
           >
@@ -64,13 +64,8 @@ function NoResultsCard() {
           <CardTitle className="text-xl font-bold">Pooled Beatmaps</CardTitle>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col space-y-4">
-        <Card className="w-full gap-2 p-6 text-center">
-          <h2 className="text-xl font-semibold">No Beatmaps Found</h2>
-          <p className="text-muted-foreground">
-            This player has no pooled beatmaps for the selected ruleset.
-          </p>
-        </Card>
+      <CardContent className="flex flex-col items-center justify-center space-y-2 text-center">
+        <p className="text-muted-foreground">No beatmap data available</p>
       </CardContent>
     </Card>
   );

--- a/apps/web/lib/orpc/queries/playerBeatmaps.ts
+++ b/apps/web/lib/orpc/queries/playerBeatmaps.ts
@@ -2,23 +2,36 @@ import { cache } from 'react';
 
 import { orpc } from '@/lib/orpc/orpc';
 import { Ruleset } from '@otr/core/osu';
-import { PlayerBeatmapStats } from '../schema/playerBeatmaps';
-
-export type PlayerBeatmapsRequest = {
-  key: string;
-  ruleset?: Ruleset;
-};
+import {
+  PlayerBeatmapsRequest,
+  PlayerBeatmapsResponse,
+} from '../schema/playerBeatmaps';
 
 export async function getPlayerBeatmaps({
-  key,
+  playerId,
   ruleset,
-}: PlayerBeatmapsRequest): Promise<PlayerBeatmapStats[]> {
+  limit,
+  offset,
+}: PlayerBeatmapsRequest): Promise<PlayerBeatmapsResponse> {
   return orpc.players.beatmaps({
-    key,
+    playerId,
     ruleset,
+    limit,
+    offset,
   });
 }
 
 export const getPlayerBeatmapsCached = cache(
-  async (key: string, ruleset?: Ruleset) => getPlayerBeatmaps({ key, ruleset })
+  async (
+    playerId: number,
+    ruleset?: Ruleset,
+    limit?: number,
+    offset?: number
+  ) =>
+    getPlayerBeatmaps({
+      playerId,
+      ruleset,
+      limit,
+      offset,
+    })
 );

--- a/apps/web/lib/orpc/queries/playerBeatmaps.ts
+++ b/apps/web/lib/orpc/queries/playerBeatmaps.ts
@@ -1,0 +1,24 @@
+import { cache } from 'react';
+
+import { orpc } from '@/lib/orpc/orpc';
+import { Ruleset } from '@otr/core/osu';
+import { PlayerBeatmapStats } from '../schema/playerBeatmaps';
+
+export type PlayerBeatmapsRequest = {
+  key: string;
+  ruleset?: Ruleset;
+};
+
+export async function getPlayerBeatmaps({
+  key,
+  ruleset,
+}: PlayerBeatmapsRequest): Promise<PlayerBeatmapStats[]> {
+  return orpc.players.beatmaps({
+    key,
+    ruleset,
+  });
+}
+
+export const getPlayerBeatmapsCached = cache(
+  async (key: string, ruleset?: Ruleset) => getPlayerBeatmaps({ key, ruleset })
+);

--- a/apps/web/lib/orpc/schema/playerBeatmaps.ts
+++ b/apps/web/lib/orpc/schema/playerBeatmaps.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod/v4';
+import { Mods } from '@otr/core/osu';
+import { RulesetSchema } from './constants';
+import { TournamentListItemSchema } from './tournament';
+
+export const BeatmapTournamentListItemSchema = TournamentListItemSchema.extend({
+  gamesPlayed: z.number().int().nonnegative().default(0),
+  mostCommonMod: z.number().int().nonnegative().default(Mods.None),
+});
+
+export const PlayerBeatmapsRequestSchema = z.object({
+  key: z.string().min(1),
+  ruleset: RulesetSchema.optional(),
+});
+
+export const PlayerBeatmapStatsSchema = z.object({
+  id: z.number().int().nonnegative(),
+  osuId: z.number().int().nonnegative().default(0),
+  rankedStatus: z.number().default(-2),
+  diffName: z.string().default(''),
+  totalLength: z.number().nonnegative().default(0),
+  drainLength: z.number().nonnegative().default(0),
+  bpm: z.number().nonnegative().default(0),
+  countCircle: z.number().int().nonnegative().default(0),
+  countSlider: z.number().int().nonnegative().default(0),
+  countSpinner: z.number().int().nonnegative().default(0),
+  cs: z.number(),
+  hp: z.number(),
+  od: z.number(),
+  ar: z.number(),
+  sr: z.number().nonnegative(),
+  maxCombo: z.number().int().nonnegative().default(0),
+  beatmapsetId: z.number().int().nonnegative(),
+  ruleset: RulesetSchema,
+  artist: z.string().default(''),
+  title: z.string().default(''),
+  tournamentCount: z.number().int().nonnegative().default(0),
+  gameCount: z.number().int().nonnegative().default(0),
+  tournaments: z.array(BeatmapTournamentListItemSchema).optional().default([]),
+});
+
+export type PlayerBeatmapsRequest = z.infer<typeof PlayerBeatmapsRequestSchema>;
+export type PlayerBeatmapStats = z.infer<typeof PlayerBeatmapStatsSchema>;
+export type BeatmapTournamentListItem = z.infer<
+  typeof BeatmapTournamentListItemSchema
+>;

--- a/apps/web/lib/orpc/schema/playerBeatmaps.ts
+++ b/apps/web/lib/orpc/schema/playerBeatmaps.ts
@@ -9,8 +9,10 @@ export const BeatmapTournamentListItemSchema = TournamentListItemSchema.extend({
 });
 
 export const PlayerBeatmapsRequestSchema = z.object({
-  key: z.string().min(1),
+  playerId: z.number().int().positive(),
   ruleset: RulesetSchema.optional(),
+  limit: z.number().int().positive().max(50).optional(),
+  offset: z.number().int().nonnegative().optional(),
 });
 
 export const PlayerBeatmapStatsSchema = z.object({
@@ -41,6 +43,11 @@ export const PlayerBeatmapStatsSchema = z.object({
 
 export type PlayerBeatmapsRequest = z.infer<typeof PlayerBeatmapsRequestSchema>;
 export type PlayerBeatmapStats = z.infer<typeof PlayerBeatmapStatsSchema>;
+export const PlayerBeatmapsResponseSchema = z.object({
+  totalCount: z.number().int().nonnegative(),
+  beatmaps: z.array(PlayerBeatmapStatsSchema),
+});
+export type PlayerBeatmapsResponse = z.infer<typeof PlayerBeatmapsResponseSchema>;
 export type BeatmapTournamentListItem = z.infer<
   typeof BeatmapTournamentListItemSchema
 >;

--- a/apps/web/lib/utils/date.ts
+++ b/apps/web/lib/utils/date.ts
@@ -1,8 +1,11 @@
+import { formatSecondsToMinutesSeconds } from '@otr/core/utils/time';
+
 /**
  * Formats a date into a string as follows: "2023-10-05 14:30:45 UTC"
  * @param date The date to format
  * @returns Formatted UTC date in "YYYY-MM-DD HH:MM:SS UTC" format
  */
+
 export function formatUTCDateFull(date: Date): string {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
@@ -41,5 +44,5 @@ export function formatDuration(seconds: number): string {
     return `${hours}:${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
   }
 
-  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  return formatSecondsToMinutesSeconds(seconds);
 }

--- a/packages/otr-core/src/index.ts
+++ b/packages/otr-core/src/index.ts
@@ -5,3 +5,4 @@ export * from './queues/constants';
 export * from './messages/values';
 export * from './messages/types';
 export * from './osu-track/user-stat-update';
+export * from './utils/time';

--- a/packages/otr-core/src/utils/time.ts
+++ b/packages/otr-core/src/utils/time.ts
@@ -1,0 +1,14 @@
+/**
+ * Formats a duration expressed in seconds into a mm:ss string.
+ * Values equal to or greater than one hour will produce an mm component
+ * that exceeds 59 rather than switching to an hours representation.
+ * @param totalSeconds Duration in seconds
+ * @returns Formatted duration string such as "3:45" or "61:03"
+ */
+export function formatSecondsToMinutesSeconds(totalSeconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
Adds a "Pooled Beatmaps" section to player profile below stats and tournament history:
<img width="1028" height="718" alt="image" src="https://github.com/user-attachments/assets/5e063077-7342-4f7d-b6ea-87664405baae" />
<img width="1023" height="715" alt="image" src="https://github.com/user-attachments/assets/7e5aac82-975b-483e-aa28-16eee437d7c4" />

Clicking "Tournaments" expands the beatmap card to show a table of tournaments that pooled the corresponding beatmap.
<img width="978" height="456" alt="image" src="https://github.com/user-attachments/assets/f9da621f-d542-4695-a758-025f53f1d00e" />

Shows up to 3 beatmaps by default, expands to show 25 more at a time when "Show More" is clicked.