### PR TITLE
Pass default ruleset into getTournaments() correctly

### DIFF
--- a/apps/web/app/players/[id]/page.tsx
+++ b/apps/web/app/players/[id]/page.tsx
@@ -151,7 +151,10 @@ export default async function PlayerPage(props: PageProps) {
     : Ruleset.Osu;
 
   // Get the list of tournaments that the player has participated in
-  const playerTournaments = await getTournaments(decodedId, searchParams);
+  const playerTournaments = await getTournaments(decodedId, {
+    ...searchParams,
+    ruleset: Number(currentRuleset).toString(),
+  });
 
   // Redirect to o!TR ID if the current URL uses a different search key
   if (canonicalPlayerId && canonicalPlayerId.toString() !== decodedId) {

--- a/apps/web/app/players/[id]/page.tsx
+++ b/apps/web/app/players/[id]/page.tsx
@@ -153,7 +153,7 @@ export default async function PlayerPage(props: PageProps) {
   // Get the list of tournaments that the player has participated in
   const playerTournaments = await getTournaments(decodedId, {
     ...searchParams,
-    ruleset: Number(currentRuleset).toString(),
+    ruleset: currentRuleset.toString(),
   });
 
   // Redirect to o!TR ID if the current URL uses a different search key


### PR DESCRIPTION
Fixes issue where tournaments from other rulesets would show up when ruleset was not specified in the URL.

https://otr.stagec.xyz/players/3616 (live):
<img width="873" height="784" alt="image" src="https://github.com/user-attachments/assets/86c407ec-cda7-49de-8fce-983c6877b5bd" />

http://localhost:3000/players/3616 (local):
<img width="1039" height="750" alt="image" src="https://github.com/user-attachments/assets/4b7bc734-716e-4e7b-9fc6-10e56c3a6c00" />
