### PR TITLE
Fix mania ruleset propogation

### DIFF
--- a/apps/data-worker/src/osu/services/__tests__/match-fetch-service.test.ts
+++ b/apps/data-worker/src/osu/services/__tests__/match-fetch-service.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveRulesetWithTournament } from '../match-fetch-service';
+import { Ruleset } from '@otr/core/osu/enums';
+
+describe('resolveRulesetWithTournament', () => {
+  it('returns the tournament mania variant when the raw ruleset is mania other', () => {
+    expect(
+      resolveRulesetWithTournament(Ruleset.ManiaOther, Ruleset.Mania4k)
+    ).toBe(Ruleset.Mania4k);
+    expect(
+      resolveRulesetWithTournament(Ruleset.ManiaOther, Ruleset.Mania7k)
+    ).toBe(Ruleset.Mania7k);
+  });
+
+  it('falls back to the raw ruleset when the tournament ruleset is not a mania variant', () => {
+    expect(
+      resolveRulesetWithTournament(Ruleset.ManiaOther, Ruleset.ManiaOther)
+    ).toBe(Ruleset.ManiaOther);
+    expect(resolveRulesetWithTournament(Ruleset.Mania4k, Ruleset.Mania7k)).toBe(
+      Ruleset.Mania4k
+    );
+    expect(resolveRulesetWithTournament(Ruleset.Catch, Ruleset.Osu)).toBe(
+      Ruleset.Catch
+    );
+  });
+});

--- a/apps/web/app/server/oRPC/procedures/tournaments/__tests__/tournamentAdminUpdateProcedure.test.ts
+++ b/apps/web/app/server/oRPC/procedures/tournaments/__tests__/tournamentAdminUpdateProcedure.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  updateTournamentAdminHandler,
+  type UpdateTournamentAdminArgs,
+} from '../adminProcedures';
+import * as schema from '@otr/core/db/schema';
+import { Ruleset, VerificationStatus } from '@otr/core/osu';
+import type { DatabaseClient } from '@/lib/db';
+
+class UpdateTournamentTestDb {
+  public readonly matches: Array<{ id: number }>;
+  public readonly games: Array<{ id: number; matchId: number }>;
+  public readonly tournamentUpdates: Array<Record<string, unknown>> = [];
+  public readonly gameUpdates: Array<Record<string, unknown>> = [];
+  public readonly gameScoreUpdates: Array<Record<string, unknown>> = [];
+  public auditCallCount = 0;
+
+  constructor(
+    private readonly existingTournament: {
+      id: number;
+      verificationStatus: number;
+      ruleset: number;
+    },
+    options: {
+      matches: Array<{ id: number }>;
+      games: Array<{ id: number; matchId: number }>;
+    }
+  ) {
+    this.matches = options.matches;
+    this.games = options.games;
+  }
+
+  query = {
+    tournaments: {
+      findFirst: async () => this.existingTournament,
+    },
+  } as const;
+
+  async transaction<T>(
+    callback: (
+      tx: UpdateTournamentTestTransaction
+    ) => Promise<T>
+  ): Promise<T> {
+    const tx = new UpdateTournamentTestTransaction(this);
+    return callback(tx);
+  }
+}
+
+class UpdateTournamentTestTransaction {
+  constructor(private readonly parent: UpdateTournamentTestDb) {}
+
+  async execute(): Promise<void> {
+    this.parent.auditCallCount += 1;
+  }
+
+  select() {
+    return {
+      from: (table: unknown) => ({
+        where: async () => {
+          if (table === schema.matches) {
+            return this.parent.matches;
+          }
+
+          if (table === schema.games) {
+            return this.parent.games;
+          }
+
+          return [];
+        },
+      }),
+    };
+  }
+
+  update(table: unknown) {
+    return {
+      set: (values: Record<string, unknown>) => ({
+        where: async () => {
+          if (table === schema.tournaments) {
+            this.parent.tournamentUpdates.push(values);
+            return;
+          }
+
+          if (table === schema.games) {
+            this.parent.gameUpdates.push(values);
+            return;
+          }
+
+          if (table === schema.gameScores) {
+            this.parent.gameScoreUpdates.push(values);
+            return;
+          }
+
+          throw new Error('Unsupported update target');
+        },
+      }),
+    };
+  }
+}
+
+describe('updateTournamentAdminHandler', () => {
+  const baseInput: UpdateTournamentAdminArgs['input'] = {
+    id: 1,
+    name: 'Test Tournament',
+    abbreviation: 'TT',
+    forumUrl: 'https://osu.ppy.sh/community/forums/topics/1',
+    rankRangeLowerBound: 1,
+    ruleset: Ruleset.Mania4k,
+    lobbySize: 2,
+    verificationStatus: VerificationStatus.None,
+    rejectionReason: 0,
+    startTime: null,
+    endTime: null,
+  };
+
+  const adminSession: NonNullable<
+    UpdateTournamentAdminArgs['context']['session']
+  > = {
+    dbUser: {
+      id: 99,
+      scopes: ['admin'],
+    },
+  };
+
+  const createContext = (
+    existingRuleset: Ruleset,
+    nextRuleset: Ruleset
+  ): UpdateTournamentAdminArgs => {
+    const db = new UpdateTournamentTestDb(
+      {
+        id: 1,
+        verificationStatus: VerificationStatus.None,
+        ruleset: existingRuleset,
+      },
+      {
+        matches: [{ id: 10 }],
+        games: [{ id: 20, matchId: 10 }],
+      }
+    );
+
+    return {
+      input: { ...baseInput, ruleset: nextRuleset },
+      context: {
+        db: db as unknown as DatabaseClient,
+        session: adminSession,
+      },
+    };
+  };
+
+  it('propagates mania variants to games and scores when switching from mania other', async () => {
+    const args = createContext(Ruleset.ManiaOther, Ruleset.Mania7k);
+    const db = args.context.db as unknown as UpdateTournamentTestDb;
+
+    const result = await updateTournamentAdminHandler(args);
+
+    expect(result.success).toBe(true);
+    expect(db.gameUpdates).toHaveLength(1);
+    expect(db.gameUpdates[0]).toEqual(
+      expect.objectContaining({
+        ruleset: Ruleset.Mania7k,
+      })
+    );
+    expect(db.gameScoreUpdates).toHaveLength(1);
+    expect(db.gameScoreUpdates[0]).toEqual(
+      expect.objectContaining({ ruleset: Ruleset.Mania7k })
+    );
+  });
+
+  it('does not propagate when the original ruleset is not mania other', async () => {
+    const args = createContext(Ruleset.Mania4k, Ruleset.Mania7k);
+    const db = args.context.db as unknown as UpdateTournamentTestDb;
+
+    const result = await updateTournamentAdminHandler(args);
+
+    expect(result.success).toBe(true);
+    expect(db.gameUpdates).toHaveLength(0);
+    expect(db.gameScoreUpdates).toHaveLength(0);
+  });
+});

--- a/packages/otr-core/src/index.ts
+++ b/packages/otr-core/src/index.ts
@@ -6,3 +6,4 @@ export * from './messages/values';
 export * from './messages/types';
 export * from './osu-track/user-stat-update';
 export * from './utils/time';
+export * from './utils/enum';

--- a/packages/otr-core/src/utils/__tests__/enum.test.ts
+++ b/packages/otr-core/src/utils/__tests__/enum.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+
+import { coerceNumericEnumValue } from '../enum';
+import { Ruleset } from '../../osu/enums';
+
+describe('coerceNumericEnumValue', () => {
+  it('returns the enum value when the number matches', () => {
+    expect(coerceNumericEnumValue(Ruleset, Ruleset.Mania4k)).toBe(
+      Ruleset.Mania4k
+    );
+    expect(coerceNumericEnumValue(Ruleset, 0)).toBe(Ruleset.Osu);
+  });
+
+  it('returns undefined when the value is not part of the enum', () => {
+    expect(coerceNumericEnumValue(Ruleset, 99)).toBeUndefined();
+    expect(coerceNumericEnumValue(Ruleset, NaN)).toBeUndefined();
+  });
+
+  it('returns the fallback when the value is invalid', () => {
+    expect(coerceNumericEnumValue(Ruleset, 99, Ruleset.Catch)).toBe(
+      Ruleset.Catch
+    );
+    expect(coerceNumericEnumValue(Ruleset, null, Ruleset.Osu)).toBe(Ruleset.Osu);
+  });
+});

--- a/packages/otr-core/src/utils/enum.ts
+++ b/packages/otr-core/src/utils/enum.ts
@@ -1,0 +1,38 @@
+export type NumericEnumValue<E extends Record<string, string | number>> = Extract<
+  E[keyof E],
+  number
+>;
+
+export function coerceNumericEnumValue<
+  E extends Record<string, string | number>
+>(
+  enumObject: E,
+  candidate: number | null | undefined
+): NumericEnumValue<E> | undefined;
+
+export function coerceNumericEnumValue<
+  E extends Record<string, string | number>
+>(
+  enumObject: E,
+  candidate: number | null | undefined,
+  fallback: NumericEnumValue<E>
+): NumericEnumValue<E>;
+
+export function coerceNumericEnumValue<
+  E extends Record<string, string | number>
+>(
+  enumObject: E,
+  candidate: number | null | undefined,
+  fallback?: NumericEnumValue<E>
+): NumericEnumValue<E> | undefined {
+  if (typeof candidate === 'number' && Number.isInteger(candidate)) {
+    if (
+      Object.prototype.hasOwnProperty.call(enumObject, candidate) &&
+      typeof enumObject[candidate as unknown as keyof E] === 'string'
+    ) {
+      return candidate as NumericEnumValue<E>;
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
When mania data is fetched, the osu! API uses `mode=3` to represent mania. This PR updates the match fetching logic to use the tournament's ruleset as the source of truth if both of these are true:

- The tournament's ruleset is either `Mania 4K` or `Mania 7K`
- The match data fetched from the osu! api has a ruleset of `Mania Other`.

This PR also adds tests for the tournament update admin procedure and adds a new enum utility

Closes #497 
Closes #512 