### PR TITLE
Make tournament/beatmap cards more compact

### DIFF
--- a/apps/web/components/player/PlayerBeatmapCard.tsx
+++ b/apps/web/components/player/PlayerBeatmapCard.tsx
@@ -46,11 +46,20 @@ export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
       <div className="absolute inset-0 z-[2] h-full w-full bg-gradient-to-b from-black/60 via-black/50 to-black/60" />
 
       <div className="relative z-[3] flex flex-col gap-3 p-4 sm:p-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex w-full items-center gap-2 sm:w-auto">
-            <span className="font-mono text-sm text-white/80">
-              /b/{beatmap.osuId}
-            </span>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex w-full gap-2 sm:w-auto">
+            <Link
+              href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}
+              target="_blank"
+              className="group/link"
+            >
+              <h2 className="text-lg font-semibold leading-tight text-white drop-shadow-sm group-hover/link:underline sm:text-xl md:text-2xl">
+                {beatmap.artist} - {beatmap.title}
+              </h2>
+              <div className="mt-1 text-sm text-white/80">
+                [{beatmap.diffName}]
+              </div>
+            </Link>
           </div>
           <div className="flex items-center gap-3 text-sm text-white/90">
             <div className="flex items-center gap-1.5">
@@ -63,17 +72,6 @@ export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
             </div>
           </div>
         </div>
-
-        <Link
-          href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}
-          target="_blank"
-          className="group/link"
-        >
-          <h2 className="text-lg font-semibold leading-tight text-white drop-shadow-sm group-hover/link:underline sm:text-xl md:text-2xl">
-            {beatmap.artist} - {beatmap.title}
-          </h2>
-          <div className="mt-1 text-sm text-white/80">[{beatmap.diffName}]</div>
-        </Link>
 
         <div className="flex flex-col gap-2 text-sm text-white/80 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">

--- a/apps/web/components/player/PlayerBeatmapCard.tsx
+++ b/apps/web/components/player/PlayerBeatmapCard.tsx
@@ -48,12 +48,8 @@ export default function PlayerBeatmapCard({ beatmap }: PlayerBeatmapCardProps) {
       <div className="relative z-[3] flex flex-col gap-3 p-4 sm:p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex w-full gap-2 sm:w-auto">
-            <Link
-              href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}
-              target="_blank"
-              className="group/link"
-            >
-              <h2 className="text-lg font-semibold leading-tight text-white drop-shadow-sm group-hover/link:underline sm:text-xl md:text-2xl">
+            <Link href={`https://osu.ppy.sh/beatmaps/${beatmap.osuId}`}>
+              <h2 className="text-lg font-semibold leading-tight text-white drop-shadow-sm sm:text-xl md:text-2xl">
                 {beatmap.artist} - {beatmap.title}
               </h2>
               <div className="mt-1 text-sm text-white/80">

--- a/apps/web/components/player/PlayerTournamentCard.tsx
+++ b/apps/web/components/player/PlayerTournamentCard.tsx
@@ -47,10 +47,7 @@ export default function PlayerTournamentCard({
   const cardContent = (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <Link
-          href={`/tournaments/${tournament.id}`}
-          className="hover:underline"
-        >
+        <Link href={`/tournaments/${tournament.id}`}>
           <h2 className="text-lg font-semibold leading-tight sm:text-xl md:text-2xl">
             {tournament.name}
           </h2>

--- a/apps/web/components/tournaments/TournamentCard.tsx
+++ b/apps/web/components/tournaments/TournamentCard.tsx
@@ -53,14 +53,12 @@ export default function TournamentCard({
 
   const cardContent = (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <VerificationBadge
-          verificationStatus={tournament.verificationStatus}
-          rejectionReason={tournament.rejectionReason}
-          entityType="tournament"
-          displayText={displayStatusText}
-        />
-        <div className="flex w-full items-center justify-between sm:w-auto sm:justify-start sm:gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <h2 className="text-lg font-semibold leading-tight sm:text-xl md:text-2xl">
+          {tournament.name}
+        </h2>
+
+        <div className="flex w-full items-center justify-between sm:w-auto sm:justify-start sm:gap-2">
           <span className="text-muted-foreground font-mono text-sm">
             {tournament.abbreviation}
           </span>
@@ -80,11 +78,14 @@ export default function TournamentCard({
         </div>
       </div>
 
-      <h2 className="text-lg font-semibold leading-tight sm:text-xl md:text-2xl">
-        {tournament.name}
-      </h2>
-
       <div className="text-muted-foreground flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+        <VerificationBadge
+          verificationStatus={tournament.verificationStatus}
+          rejectionReason={tournament.rejectionReason}
+          entityType="tournament"
+          displayText={displayStatusText}
+        />
+
         <div className="flex items-center gap-1.5">
           <RulesetIcon
             ruleset={tournament.ruleset}

--- a/apps/web/components/tournaments/list/TournamentList.tsx
+++ b/apps/web/components/tournaments/list/TournamentList.tsx
@@ -167,7 +167,7 @@ export default function TournamentList({
 
             return (
               <div
-                className="relative w-full pb-5"
+                className="relative w-full pb-3"
                 key={item.key}
                 data-index={item.index}
                 ref={virtualizer.measureElement}


### PR DESCRIPTION
tournaments page:
<img width="1220" height="760" alt="image" src="https://github.com/user-attachments/assets/1a500f48-9d39-412a-ac6b-d0eadc555f46" />

pooled beatmaps:
<img width="1190" height="715" alt="image" src="https://github.com/user-attachments/assets/5796ffdc-3bdb-4d34-8426-22980627a0a6" />
