### PR TITLE
API key usage log formatting

### DIFF
--- a/apps/data-worker/src/logging/logger.ts
+++ b/apps/data-worker/src/logging/logger.ts
@@ -9,10 +9,16 @@ const log = (
   message: string,
   extra?: Record<string, unknown>
 ) => {
+  const timestamp = new Date().toISOString();
+  const formattedMessage = `timestamp=${timestamp} ${message}`;
+
   if (extra && Object.keys(extra).length > 0) {
-    writer.call(console, message, extra);
+    writer.call(console, formattedMessage, {
+      ...extra,
+      timestamp,
+    });
   } else {
-    writer.call(console, message);
+    writer.call(console, formattedMessage);
   }
 };
 


### PR DESCRIPTION
Example log: `2025-10-17T01:09:32.739Z [oRPC]: procedure=players.get user="Stage" playerId=440 apiKey=h0I9n... args={"id":440} duration=2ms status=ok`