### PR TITLE
Fix sub-tier calculation

### DIFF
--- a/apps/web/lib/utils/tierProgress.ts
+++ b/apps/web/lib/utils/tierProgress.ts
@@ -102,10 +102,7 @@ export const buildTierProgress = (rating: number) => {
   const majorRange = Math.max(nextBounds.min - currentBounds.min, 1);
   const subTierRange = majorRange / SUB_TIERS;
   const progressInTier = Math.max(0, rating - currentBounds.min);
-  const currentSubTier = Math.min(
-    SUB_TIERS,
-    Math.floor(progressInTier / subTierRange) + 1
-  );
+  const currentSubTier = SUB_TIERS - Math.floor(progressInTier / subTierRange);
   const currentSubTierBase =
     currentBounds.min + subTierRange * (currentSubTier - 1);
   const ratingForNextTier = Math.min(


### PR DESCRIPTION
rank now correctly shows as Platinum I:
<img width="1157" height="574" alt="image" src="https://github.com/user-attachments/assets/d858a580-869d-44c9-a1d3-b97c905036ba" />

Fixes #572 