### PR TITLE
Add way for users to delete their own data

### DIFF
--- a/apps/web/app/server/oRPC/router.ts
+++ b/apps/web/app/server/oRPC/router.ts
@@ -28,7 +28,11 @@ import {
   getPlayerTournaments,
 } from './procedures/playerProcedures';
 import { searchEntities } from './procedures/searchProcedures';
-import { getCurrentUser, getUser } from './procedures/userProcedures';
+import {
+  deleteMyAccount,
+  getCurrentUser,
+  getUser,
+} from './procedures/userProcedures';
 import {
   banUserAdmin,
   listUserApiKeysAdmin,
@@ -87,6 +91,7 @@ export const router = base.router({
   },
   users: {
     me: getCurrentUser,
+    deleteMe: deleteMyAccount,
     admin: {
       search: searchPlayersAdmin,
       lookup: lookupAuthUserAdmin,

--- a/apps/web/app/settings/AccountDeletionClient.tsx
+++ b/apps/web/app/settings/AccountDeletionClient.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Trash2, UserX } from 'lucide-react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { orpc } from '@/lib/orpc/orpc';
+import { authClient } from '@/lib/auth/auth-client';
+
+export default function AccountDeletionClient() {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+
+    try {
+      await orpc.users.deleteMe();
+
+      toast.success('Account deleted successfully');
+
+      await authClient.signOut({
+        fetchOptions: {
+          onSuccess: () => {
+            router.push('/');
+          },
+        },
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Failed to delete account. Please try again.';
+      toast.error(message);
+      setIsDeleting(false);
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">Account Deletion</h2>
+        <p className="text-muted-foreground text-sm sm:text-base">
+          Permanently delete your account and remove your data from o!TR.
+        </p>
+      </div>
+
+      <Card className="border-destructive/50">
+        <CardHeader className="flex flex-col gap-4">
+          <div className="flex items-center gap-3">
+            <UserX className="text-destructive size-6" />
+            <div>
+              <CardTitle className="text-destructive">Delete Account</CardTitle>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <div className="text-muted-foreground text-sm sm:text-base">
+            <p>
+              This will permanently delete your user account and associated
+              data. Your player profile will remain publicly accessible.
+            </p>
+          </div>
+
+          <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+            <AlertDialogTrigger asChild>
+              <Button
+                variant="destructive"
+                className="w-full sm:w-auto"
+                disabled={isDeleting}
+              >
+                <Trash2 className="mr-2 size-4" />
+                Delete My Account
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete your account?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={isDeleting}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleDeleteAccount}
+                  className="bg-destructive hover:bg-destructive/90 focus-visible:ring-destructive/40 text-white"
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? 'Deleting...' : 'Delete Account'}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -2,6 +2,7 @@ import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { Settings } from 'lucide-react';
 
+import AccountDeletionClient from '@/app/settings/AccountDeletionClient';
 import ApiKeySettingsClient from '@/app/settings/ApiKeySettingsClient';
 import { auth } from '@/lib/auth/auth';
 import { orpc } from '@/lib/orpc/orpc';
@@ -32,6 +33,7 @@ export default async function SettingsPage() {
           initialKeys={keys}
           rateLimit={{ maxRequests: 60, timeWindowMs: 60_000 }}
         />
+        <AccountDeletionClient />
       </div>
     </div>
   );


### PR DESCRIPTION
Allows users to nuke their accounts in the settings panel. Any tables which depend on a user_id will have associated entries wiped when the user record is removed.