### PR TITLE
Disable Friends leaderboard tab when no friends synced

### DIFF
--- a/apps/web/app/leaderboard/LeaderboardTabs.tsx
+++ b/apps/web/app/leaderboard/LeaderboardTabs.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface LeaderboardTabsProps {
+  currentTab: 'all' | 'friends';
+  allTabHref: string;
+  friendsTabHref: string;
+  hasFriends: boolean;
+}
+
+export default function LeaderboardTabs({
+  currentTab,
+  allTabHref,
+  friendsTabHref,
+  hasFriends,
+}: LeaderboardTabsProps) {
+  return (
+    <Tabs value={currentTab} className="w-auto">
+      <TabsList>
+        <TabsTrigger value="all" asChild>
+          <Link href={allTabHref}>All</Link>
+        </TabsTrigger>
+        {hasFriends ? (
+          <TabsTrigger value="friends" asChild>
+            <Link href={friendsTabHref}>Friends</Link>
+          </TabsTrigger>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>
+                <TabsTrigger value="friends" disabled>
+                  Friends
+                </TabsTrigger>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>Sync friends in settings to enable</TooltipContent>
+          </Tooltip>
+        )}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -2,15 +2,13 @@ import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { Settings } from 'lucide-react';
 import { Suspense } from 'react';
-import { eq, sql } from 'drizzle-orm';
 
 import AccountDeletionClient from '@/app/settings/AccountDeletionClient';
 import ApiKeySettingsClient from '@/app/settings/ApiKeySettingsClient';
 import FriendsSyncClient from '@/app/settings/FriendsSyncClient';
 import { auth } from '@/lib/auth/auth';
 import { orpc } from '@/lib/orpc/orpc';
-import { db } from '@/lib/db';
-import * as schema from '@otr/core/db/schema';
+import { getFriendCount } from '@/lib/db/player-friends';
 
 export default async function SettingsPage() {
   const headersList = await headers();
@@ -23,15 +21,7 @@ export default async function SettingsPage() {
   const keys = await orpc.apiClients.getKeys();
 
   const playerId = appSession.dbPlayer?.id;
-  let friendCount = 0;
-
-  if (playerId) {
-    const result = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(schema.playerFriends)
-      .where(eq(schema.playerFriends.playerId, playerId));
-    friendCount = result[0]?.count ?? 0;
-  }
+  const friendCount = playerId ? await getFriendCount(playerId) : 0;
 
   return (
     <div className="flex flex-col gap-10">

--- a/apps/web/lib/db/player-friends.ts
+++ b/apps/web/lib/db/player-friends.ts
@@ -1,0 +1,16 @@
+import { db } from '@/lib/db';
+import * as schema from '@otr/core/db/schema';
+import { eq, sql } from 'drizzle-orm';
+
+export async function getFriendCount(playerId: number): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(schema.playerFriends)
+    .where(eq(schema.playerFriends.playerId, playerId));
+  return result[0]?.count ?? 0;
+}
+
+export async function hasFriends(playerId: number): Promise<boolean> {
+  const count = await getFriendCount(playerId);
+  return count > 0;
+}


### PR DESCRIPTION
- Shows Friends tab as disabled with tooltip "Sync friends in settings to enable" when user has no friends synced
- Extracts friend count logic into reusable `hasFriends()` and `getFriendCount()` utilities