### PR TITLE
Add Discord notifications for releases

### DIFF
--- a/.github/workflows/release-discord.yml
+++ b/.github/workflows/release-discord.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: SethCohen/github-releases-to-discord@v1
         with:
           webhook_url: ${{ secrets.CHANGELOG_WEBHOOK_URL }}
-          color: "2105893"
-          username: "o!TR Releases"
-          content: "||@changelog||"
-          footer_title: "Changelog"
+          color: '2105893'
+          username: 'o!TR Releases'
+          content: '||@changelog||'
+          footer_title: 'Changelog'
           footer_timestamp: true
           reduce_headings: true


### PR DESCRIPTION
- Adds new workflow to post release changelogs to Discord
- Uses `github-releases-to-discord` action
- Triggers on release publish events