### PR TITLE
Handle 401/403 errors in data worker to prevent queue deadlock

### DIFF
--- a/apps/data-worker/src/osu/api-helpers.ts
+++ b/apps/data-worker/src/osu/api-helpers.ts
@@ -13,3 +13,27 @@ export const withNotFoundHandling = async <T>(
     throw error;
   }
 };
+
+export type ApiCallResult<T> =
+  | { status: 'success'; data: T }
+  | { status: 'not_found' }
+  | { status: 'unauthorized' };
+
+export const withApiErrorHandling = async <T>(
+  invoke: () => Promise<T>
+): Promise<ApiCallResult<T>> => {
+  try {
+    const data = await invoke();
+    return { status: 'success', data };
+  } catch (error) {
+    if (error instanceof APIError) {
+      if (error.status_code === 404) {
+        return { status: 'not_found' };
+      }
+      if (error.status_code === 401 || error.status_code === 403) {
+        return { status: 'unauthorized' };
+      }
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
- Add `withApiErrorHandling` helper that returns results for 404/401/403 errors
- Update data fetch services to handle unauthorized responses
- Set `DataFetchStatus.Error` and consume message (no re-enqueue) on 401/403