### PR TITLE
Display rating values with two decimal places in filter reports

### DIFF
--- a/apps/web/components/filtering/FilteringResultsTable.tsx
+++ b/apps/web/components/filtering/FilteringResultsTable.tsx
@@ -97,7 +97,7 @@ export default function FilteringResultsTable({
         cell: ({ getValue }) => (
           <NumericCell
             value={getValue() as number | undefined | null}
-            format={(v) => v.toFixed(0)}
+            format={(v) => v.toFixed(2)}
           />
         ),
       },
@@ -109,7 +109,7 @@ export default function FilteringResultsTable({
         cell: ({ getValue }) => (
           <NumericCell
             value={getValue() as number | undefined | null}
-            format={(v) => v.toFixed(0)}
+            format={(v) => v.toFixed(2)}
           />
         ),
       },


### PR DESCRIPTION
- Change rating and peak rating display from `.toFixed(0)` to `.toFixed(2)` in filter results table
- Resolves #644