### PR TITLE
Add win/loss statistics to player tournament history

### DIFF
--- a/apps/web/app/players/[id]/page.tsx
+++ b/apps/web/app/players/[id]/page.tsx
@@ -12,7 +12,7 @@ import { getPlayerBeatmapsCached } from '@/lib/orpc/queries/playerBeatmaps';
 import { getPlayerStatsCached } from '@/lib/orpc/queries/playerStats';
 import { getPlayerTournamentsCached } from '@/lib/orpc/queries/playerTournaments';
 import type { PlayerStats } from '@/lib/orpc/schema/playerStats';
-import { TournamentListItem } from '@/lib/orpc/schema/tournament';
+import { PlayerTournamentListItem } from '@/lib/orpc/schema/tournament';
 import { Ruleset } from '@otr/core/osu';
 import { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
@@ -96,7 +96,7 @@ async function getPlayerData(
 async function getTournaments(
   playerId: number,
   searchParams: { [key: string]: string | string[] | undefined }
-): Promise<TournamentListItem[]> {
+): Promise<PlayerTournamentListItem[]> {
   if (playerId <= 0) {
     return [];
   }

--- a/apps/web/components/player/PlayerTournamentCard.tsx
+++ b/apps/web/components/player/PlayerTournamentCard.tsx
@@ -6,14 +6,14 @@ import VerificationBadge from '../badges/VerificationBadge';
 import { LazerBadge } from '../badges/LazerBadge';
 import { Card } from '../ui/card';
 import RulesetIcon from '../icons/RulesetIcon';
-import { Users, Target, Calendar, Eye, EyeOff } from 'lucide-react';
+import { Users, Target, Calendar, Eye, EyeOff, Swords } from 'lucide-react';
 import RatingDelta from '../rating/RatingDelta';
 import { Button } from '../ui/button';
 import { useState } from 'react';
 import PlayerTournamentMatchTable from './PlayerTournamentMatchTable';
 import { cn } from '@/lib/utils';
 import { PlayerRatingAdjustment } from '@/lib/orpc/schema/playerStats';
-import { TournamentListItem } from '@/lib/orpc/schema/tournament';
+import { PlayerTournamentListItem } from '@/lib/orpc/schema/tournament';
 
 function formatRankRangeDisplay(rankRange: number): string {
   if (rankRange === 1) return 'Open';
@@ -21,7 +21,7 @@ function formatRankRangeDisplay(rankRange: number): string {
 }
 
 interface PlayerTournamentCardProps {
-  tournament: TournamentListItem;
+  tournament: PlayerTournamentListItem;
   adjustments: PlayerRatingAdjustment[];
 }
 
@@ -58,6 +58,12 @@ export default function PlayerTournamentCard({
           <span className="text-muted-foreground font-mono text-sm">
             {tournament.abbreviation}
           </span>
+          <div className="text-muted-foreground flex items-center gap-1 text-sm">
+            <Swords className="h-4 w-4" />
+            <span>
+              {tournament.matchesWon}-{tournament.matchesLost}
+            </span>
+          </div>
           <RatingDelta delta={totalRatingDelta} />
         </div>
       </div>

--- a/apps/web/components/player/PlayerTournamentMatchTable.tsx
+++ b/apps/web/components/player/PlayerTournamentMatchTable.tsx
@@ -12,6 +12,8 @@ import {
 import { format } from 'date-fns';
 import Link from 'next/link';
 import RatingDelta from '@/components/rating/RatingDelta';
+import SimpleTooltip from '@/components/simple-tooltip';
+import { HelpCircle } from 'lucide-react';
 
 const RATING_PRECISION = {
   DISPLAY: 0,
@@ -36,6 +38,14 @@ export default function PlayerTournamentMatchTable({
             <TableRow>
               <TableHead className="bg-muted/50">Date</TableHead>
               <TableHead className="bg-muted/50">Match</TableHead>
+              <TableHead className="bg-muted/50 text-center">
+                <div className="flex items-center justify-center gap-1">
+                  Games (W-L)
+                  <SimpleTooltip content="Win-loss record for games this player participated in, not the entire team">
+                    <HelpCircle className="h-4 w-4" />
+                  </SimpleTooltip>
+                </div>
+              </TableHead>
               <TableHead className="bg-muted/50 text-center">Before</TableHead>
               <TableHead className="bg-muted/50 text-center">After</TableHead>
               <TableHead className="bg-muted/50 text-center">Change</TableHead>
@@ -65,6 +75,16 @@ export default function PlayerTournamentMatchTable({
                       </span>
                     )}
                   </TableCell>
+                  <TableCell className="py-2 text-center text-xs sm:text-sm">
+                    {adjustment.gamesWon != null &&
+                    adjustment.gamesLost != null ? (
+                      <span>
+                        {adjustment.gamesWon}-{adjustment.gamesLost}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
                   <TableCell className="text-muted-foreground py-2 text-center text-xs sm:text-sm">
                     {adjustment.ratingBefore.toFixed(RATING_PRECISION.DISPLAY)}
                   </TableCell>
@@ -79,7 +99,7 @@ export default function PlayerTournamentMatchTable({
             ) : (
               <TableRow>
                 <TableCell
-                  colSpan={5}
+                  colSpan={6}
                   className="text-muted-foreground h-24 text-center"
                 >
                   No matches found.

--- a/apps/web/components/player/PlayerTournamentsList.tsx
+++ b/apps/web/components/player/PlayerTournamentsList.tsx
@@ -4,12 +4,12 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Trophy } from 'lucide-react';
 import { useState } from 'react';
-import { TournamentListItem } from '@/lib/orpc/schema/tournament';
+import { PlayerTournamentListItem } from '@/lib/orpc/schema/tournament';
 import { PlayerRatingAdjustment } from '@/lib/orpc/schema/playerStats';
 import PlayerTournamentCard from './PlayerTournamentCard';
 
 interface PlayerTournamentsListProps {
-  tournaments: TournamentListItem[];
+  tournaments: PlayerTournamentListItem[];
   adjustments: PlayerRatingAdjustment[];
 }
 

--- a/apps/web/lib/orpc/queries/playerTournaments.ts
+++ b/apps/web/lib/orpc/queries/playerTournaments.ts
@@ -1,7 +1,7 @@
 import { cache } from 'react';
 
 import { orpc } from '@/lib/orpc/orpc';
-import type { TournamentListItem } from '@/lib/orpc/schema/tournament';
+import type { PlayerTournamentListItem } from '@/lib/orpc/schema/tournament';
 import { Ruleset } from '@otr/core/osu';
 
 export type PlayerTournamentsRequest = {
@@ -19,7 +19,7 @@ export async function getPlayerTournaments({
   dateMin,
   dateMax,
   ruleset,
-}: PlayerTournamentsRequest): Promise<TournamentListItem[]> {
+}: PlayerTournamentsRequest): Promise<PlayerTournamentListItem[]> {
   return orpc.players.tournaments({
     id,
     keyType: 'otr',

--- a/apps/web/lib/orpc/schema/playerStats.ts
+++ b/apps/web/lib/orpc/schema/playerStats.ts
@@ -58,6 +58,9 @@ export const PlayerRatingAdjustmentSchema = ratingAdjustmentBaseSchema.extend({
   ratingDelta: z.number(),
   volatilityDelta: z.number(),
   match: PlayerMatchReferenceSchema.nullable(),
+  gamesWon: z.number().int().nonnegative().nullable(),
+  gamesLost: z.number().int().nonnegative().nullable(),
+  matchWon: z.boolean().nullable(),
 });
 
 const playerRatingBaseSchema = playerRatingSelectSchema

--- a/apps/web/lib/orpc/schema/tournament.ts
+++ b/apps/web/lib/orpc/schema/tournament.ts
@@ -58,6 +58,11 @@ export const TournamentListItemSchema = tournamentSelectSchema
 
 export const TournamentListResponseSchema = TournamentListItemSchema.array();
 
+export const PlayerTournamentListItemSchema = TournamentListItemSchema.extend({
+  matchesWon: z.number().int(),
+  matchesLost: z.number().int(),
+});
+
 export const TournamentAdminNoteSchema = AdminNoteSchema;
 
 const AdminNoteContentSchema = z.string().trim().min(1);
@@ -223,6 +228,9 @@ export type { VerificationStatusValue };
 
 export type TournamentListRequest = z.infer<typeof TournamentListRequestSchema>;
 export type TournamentListItem = z.infer<typeof TournamentListItemSchema>;
+export type PlayerTournamentListItem = z.infer<
+  typeof PlayerTournamentListItemSchema
+>;
 export type TournamentAdminNote = z.infer<typeof TournamentAdminNoteSchema>;
 export type TournamentAdminNoteCreateInput = z.infer<
   typeof TournamentAdminNoteCreateInputSchema


### PR DESCRIPTION
- Display match W-L record on tournament cards in player history
- Add games W-L column with tooltip to match table explaining it shows individual player's games, not team totals
- Create PlayerTournamentListItem type extending TournamentListItem with matchesWon/matchesLost
- Add gamesWon, gamesLost, matchWon fields to PlayerRatingAdjustment

<img width="1455" height="1433" alt="Screenshot_20251227_161430" src="https://github.com/user-attachments/assets/4fc90582-803b-4d91-be4f-b0c7af4f6973" />

Closes #538