### PR TITLE
Fix false positive in unpooled beatmap warning for replayed warmups

### DIFF
--- a/apps/data-worker/src/automation-checks/__tests__/match-automation-checks.test.ts
+++ b/apps/data-worker/src/automation-checks/__tests__/match-automation-checks.test.ts
@@ -91,12 +91,19 @@ describe('MatchAutomationChecks', () => {
     ).not.toBe(0);
   });
 
-  it('adds warning when beatmaps outside first two games are not pooled', () => {
+  it('adds warning when more than two unique beatmaps are not pooled', () => {
     const games = [
-      createGame({}),
-      createGame({}),
       createGame({
         rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 1, osuId: 1001 },
+      }),
+      createGame({
+        rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 2, osuId: 1002 },
+      }),
+      createGame({
+        rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 3, osuId: 1003 },
       }),
     ];
     const match = createMatch({ games });
@@ -107,6 +114,31 @@ describe('MatchAutomationChecks', () => {
     expect(
       match.warningFlags & MatchWarningFlags.UnexpectedBeatmapsFound
     ).not.toBe(0);
+  });
+
+  it('does not warn when replayed warmup results in only two unique unpooled beatmaps', () => {
+    const games = [
+      createGame({
+        rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 1, osuId: 1001 },
+      }),
+      createGame({
+        rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 2, osuId: 1001 },
+      }),
+      createGame({
+        rejectionReason: GameRejectionReason.BeatmapNotPooled,
+        beatmap: { id: 3, osuId: 1002 },
+      }),
+    ];
+    const match = createMatch({ games });
+    const tournament = createTournament({ matches: [match] });
+
+    checker.process(match, tournament);
+
+    expect(match.warningFlags & MatchWarningFlags.UnexpectedBeatmapsFound).toBe(
+      0
+    );
   });
 
   it('detects overlapping rosters across games', () => {

--- a/apps/data-worker/src/automation-checks/match-automation-checks.ts
+++ b/apps/data-worker/src/automation-checks/match-automation-checks.ts
@@ -199,24 +199,19 @@ export class MatchAutomationChecks {
   }
 
   private applyBeatmapWarning(match: AutomationMatch) {
-    const games = [...match.games].sort((a, b) => {
-      const startA = a.startTime ?? '';
-      const startB = b.startTime ?? '';
-      return startA.localeCompare(startB);
-    });
+    const unpooledBeatmapIds = new Set<number>();
 
-    if (games.length < 3) {
-      return;
+    for (const game of match.games) {
+      if (
+        (game.rejectionReason & GameRejectionReason.BeatmapNotPooled) ===
+          GameRejectionReason.BeatmapNotPooled &&
+        game.beatmap
+      ) {
+        unpooledBeatmapIds.add(game.beatmap.osuId);
+      }
     }
 
-    const extraGames = games.slice(2);
-    if (
-      extraGames.some(
-        (game) =>
-          (game.rejectionReason & GameRejectionReason.BeatmapNotPooled) ===
-          GameRejectionReason.BeatmapNotPooled
-      )
-    ) {
+    if (unpooledBeatmapIds.size > 2) {
       match.warningFlags = addWarningFlag(
         match.warningFlags,
         MatchWarningFlags.UnexpectedBeatmapsFound


### PR DESCRIPTION
- Check unique beatmap IDs with BeatmapNotPooled rejection instead of game indices
- Only apply warning when more than 2 unique beatmaps are rejected
- Fixes false positives when warmups are cancelled and replayed

Closes #513