### PR TITLE
Fix `/tournaments` filter date picker layout

### DIFF
--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -11,17 +11,22 @@ function Calendar({
   className,
   classNames,
   showOutsideDays = true,
+  captionLayout,
   ...props
 }: React.ComponentProps<typeof DayPicker>) {
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
+      captionLayout={captionLayout}
       className={cn('p-3', className)}
       classNames={{
         months: 'flex flex-col sm:flex-row gap-2',
         month: 'flex flex-col gap-4',
         caption: 'flex justify-center pt-1 relative items-center w-full',
-        caption_label: 'text-sm font-medium',
+        caption_label: cn(
+          'text-sm font-medium',
+          captionLayout === 'dropdown' && 'hidden'
+        ),
         nav: 'flex items-center gap-1',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),
@@ -72,6 +77,11 @@ function Calendar({
           <ChevronRight className={cn('size-4', className)} {...props} />
         ),
       }}
+      labels={
+        captionLayout === 'dropdown'
+          ? { labelMonthDropdown: () => '', labelYearDropdown: () => '' }
+          : undefined
+      }
       {...props}
     />
   );


### PR DESCRIPTION
Before (staging)

<img width="1232" height="1180" alt="image" src="https://github.com/user-attachments/assets/dc73e9ec-a623-498d-95bb-1e309e89ea34" />

After

<img width="1197" height="1200" alt="image" src="https://github.com/user-attachments/assets/66817337-b4a8-48ee-ac39-3e277abcf3a7" />
