### PR TITLE
Specify node-exporter profile, discord webhook fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,8 +94,8 @@ jobs:
             export WEB_IMAGE="stagecodes/otr-web:${{ inputs.deploy_tag }}"
             export DATA_WORKER_IMAGE="stagecodes/otr-data-worker:${{ inputs.deploy_tag }}"
             cd "$REMOTE_PATH"
-            docker compose --env-file .env pull web data-worker
-            docker compose --env-file .env up -d db rabbitmq prometheus grafana postgres-exporter node-exporter
+            docker compose --env-file .env pull
             docker compose --env-file .env --profile migrate run --rm migrate
+            docker compose --env-file .env --profile node-exporter up -d
             docker compose --env-file .env up -d --remove-orphans
           envs: REMOTE_PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,6 @@ services:
       - ./monitoring/prometheus/rules:/etc/prometheus/rules:ro
     depends_on:
       - postgres-exporter
-      - node-exporter
 
   loki:
     image: grafana/loki:3.4.1
@@ -225,7 +224,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_SECURITY_SECRET_KEY: ${GRAFANA_SECRET_KEY}
       GF_USERS_ALLOW_SIGN_UP: 'false'
-      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
+      DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL:-NULL}
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -256,6 +255,8 @@ services:
     volumes:
       - /:/host:ro,rslave
     pid: host
+    profiles:
+      - 'node-exporter'
 
 volumes:
   postgres-data:


### PR DESCRIPTION
Adds a `node-exporter` profile as this is not necessary to run for local development. It's used for monitoring of the host system metrics. Adds a fallback `DISCORD_WEBHOOK_URL` value to bypass in local development.