### PR TITLE
Loki config tuning

### DIFF
--- a/monitoring/loki/loki-config.yaml
+++ b/monitoring/loki/loki-config.yaml
@@ -40,12 +40,13 @@ storage_config:
     cache_location: /loki/tsdb-cache
 
 limits_config:
-  retention_period: 30d
+  retention_period: 90d
   allow_structured_metadata: true
   volume_enabled: true
   ingestion_rate_mb: 16
   ingestion_burst_size_mb: 32
-  max_query_parallelism: 32
+  max_query_parallelism: 2
+  max_query_series: 100000
 
 compactor:
   working_directory: /loki/compactor


### PR DESCRIPTION
- Enables larger query sizes, 90d retention period, and reduces parallelism to 2 threads