### PR TITLE
Fix player link on match stats page using osuId instead of playerId

### DIFF
--- a/apps/web/components/matches/MatchStatsPlayerRow.tsx
+++ b/apps/web/components/matches/MatchStatsPlayerRow.tsx
@@ -52,7 +52,7 @@ const MatchStatsPlayerRow = React.memo(function MatchStatsPlayerRow({
       {/* Player column */}
       <TableCell className="w-[140px] max-w-[160px] py-2">
         <Link
-          href={`/players/${player.osuId}`}
+          href={`/players/${player.playerId}`}
           className="flex items-center gap-2 transition-opacity hover:opacity-80 sm:gap-2.5"
         >
           {!imageError ? (


### PR DESCRIPTION
Player name links on the match stats page navigated to /players/{osuId} instead of /players/{playerId}, causing wrong player resolution when an osu\! ID collides with a different player's internal ID.

Closes #712