### PR TITLE
Move rejection reason dropdown inline with checkbox

### DIFF
--- a/apps/web/components/tournaments/TournamentSubmissionForm.tsx
+++ b/apps/web/components/tournaments/TournamentSubmissionForm.tsx
@@ -355,81 +355,79 @@ export default function TournamentSubmissionForm() {
             />
           </div>
 
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-row items-center gap-4">
-              <FormField
-                control={form.control}
-                name="isLazer"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-center gap-2 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
-                    <LabelWithTooltip
-                      label="Played on osu!lazer"
-                      tooltip="Check this if the tournament was played on osu!lazer instead of osu!stable"
+          <div className="flex flex-row items-center gap-4">
+            <FormField
+              control={form.control}
+              name="isLazer"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center gap-2 space-y-0">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
                     />
-                  </FormItem>
-                )}
-              />
-
-              {isAdmin && (
-                <div className="flex flex-row items-center gap-2">
-                  <Checkbox
-                    checked={rejectOnSubmit}
-                    onClick={() => setRejectOnSubmit((prev) => !prev)}
+                  </FormControl>
+                  <LabelWithTooltip
+                    label="Played on osu!lazer"
+                    tooltip="Check this if the tournament was played on osu!lazer instead of osu!stable"
                   />
-                  <FormLabel className="text-foreground font-medium">
-                    Reject this tournament on submission
-                  </FormLabel>
-                </div>
+                </FormItem>
               )}
-            </div>
+            />
 
-            {isAdmin && rejectOnSubmit && (
-              <FormField
-                control={form.control}
-                name="rejectionReason"
-                render={({
-                  field: { onChange, value },
-                  fieldState: { invalid },
-                }) => (
-                  <FormItem>
-                    <FormControl>
-                      <MultipleSelect
-                        placeholder="Select rejection reason"
-                        options={Object.entries(
-                          TournamentRejectionReasonEnumHelper.metadata
-                        )
-                          .filter(
-                            ([v]) =>
-                              Number(v) !== TournamentRejectionReason.None
-                          )
-                          .map(([v, { text }]) => ({
-                            value: v,
-                            label: text,
-                          }))}
-                        selected={TournamentRejectionReasonEnumHelper.getFlags(
-                          value
-                        ).map(String)}
-                        onChange={(values: string[]) => {
-                          let flag = 0;
-                          values.forEach((v: string) => {
-                            flag |= Number(v);
-                          });
+            {isAdmin && (
+              <div className="flex flex-row items-center gap-2">
+                <Checkbox
+                  checked={rejectOnSubmit}
+                  onClick={() => setRejectOnSubmit((prev) => !prev)}
+                />
+                <FormLabel className="text-foreground font-medium">
+                  Reject this tournament on submission
+                </FormLabel>
+                {rejectOnSubmit && (
+                  <FormField
+                    control={form.control}
+                    name="rejectionReason"
+                    render={({
+                      field: { onChange, value },
+                      fieldState: { invalid },
+                    }) => (
+                      <FormItem>
+                        <FormControl>
+                          <MultipleSelect
+                            placeholder="Select rejection reason"
+                            options={Object.entries(
+                              TournamentRejectionReasonEnumHelper.metadata
+                            )
+                              .filter(
+                                ([v]) =>
+                                  Number(v) !==
+                                  TournamentRejectionReason.None
+                              )
+                              .map(([v, { text }]) => ({
+                                value: v,
+                                label: text,
+                              }))}
+                            selected={TournamentRejectionReasonEnumHelper.getFlags(
+                              value
+                            ).map(String)}
+                            onChange={(values: string[]) => {
+                              let flag = 0;
+                              values.forEach((v: string) => {
+                                flag |= Number(v);
+                              });
 
-                          onChange(flag);
-                        }}
-                        invalid={invalid}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
+                              onChange(flag);
+                            }}
+                            invalid={invalid}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
                 )}
-              />
+              </div>
             )}
           </div>
 

--- a/apps/web/components/tournaments/TournamentSubmissionForm.tsx
+++ b/apps/web/components/tournaments/TournamentSubmissionForm.tsx
@@ -401,8 +401,7 @@ export default function TournamentSubmissionForm() {
                             )
                               .filter(
                                 ([v]) =>
-                                  Number(v) !==
-                                  TournamentRejectionReason.None
+                                  Number(v) !== TournamentRejectionReason.None
                               )
                               .map(([v, { text }]) => ({
                                 value: v,


### PR DESCRIPTION
- Move the rejection reason `MultipleSelect` inside the admin checkbox `div` so it renders inline next to the "Reject on submission" checkbox
- Simplify outer wrapper from `flex-col` to single `flex-row` since it no longer has a second child

Closes #732


<img width="1964" height="650" alt="CleanShot 2026-02-19 at 11 04 58@2x" src="https://github.com/user-attachments/assets/9e14708e-fc81-49ec-bccb-a319503dd979" />