### PR TITLE
Implement beatmap file download and storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,13 @@ RABBITMQ_AMQP_URL=amqp://admin:admin@localhost:5672/
 BETTER_AUTH_SECRET=replace-with-secret
 BETTER_AUTH_URL=http://localhost:3000
 
-## Google Cloud Storage credentials
+## Beatmap file storage
+## GCS is used when GOOGLE_APPLICATION_CREDENTIALS and GCS_BEATMAP_BUCKET_NAME are provided.
+## Falls back to local disk otherwise.
 GOOGLE_APPLICATION_CREDENTIALS=replace-with-path-to-service-account-key
+GCS_BEATMAP_BUCKET_NAME=replace-with-bucket-name
+## Relative to project root
+BEATMAP_FILE_LOCAL_PATH=beatmap-storage
 
 ## osu! API v2 credentials and rate limits
 DATA_WORKER_OSU_CLIENT_ID=replace-with-worker-client-id

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,9 @@ BETTER_AUTH_URL=http://localhost:3000
 ## Falls back to local disk otherwise.
 GOOGLE_APPLICATION_CREDENTIALS=replace-with-path-to-service-account-key
 GCS_BEATMAP_BUCKET_NAME=replace-with-bucket-name
-## Relative to project root
+## When not using GCS, beatmap files will be downloaded and stored to this directory.
+## Paths are resolved relative to the project root. For example a value of
+## 'beatmap-storage' will resolve to '/your-code-dir/otr-web/beatmap-storage'
 BEATMAP_FILE_LOCAL_PATH=beatmap-storage
 
 ## osu! API v2 credentials and rate limits

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ monitoring/loki/data/
 
 # top-level images (playwright mcp)
 *.png
+
+# data-worker local beatmap storage
+*.osu
+*.osu.gz

--- a/apps/data-worker/package.json
+++ b/apps/data-worker/package.json
@@ -10,6 +10,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@google-cloud/storage": "^7.19.0",
     "@otr/core": "workspace:*",
     "amqplib": "^0.10.4",
     "drizzle-orm": "^0.44.5",

--- a/apps/data-worker/src/env.ts
+++ b/apps/data-worker/src/env.ts
@@ -1,4 +1,5 @@
-import { loadRootEnv } from '../../../lib/env/load-root-env';
+import { loadRootEnv, projectRoot } from '../../../lib/env/load-root-env';
+import path from 'path';
 
 loadRootEnv();
 
@@ -107,6 +108,12 @@ export const dataWorkerEnv = {
   beatmapAttrCreationEnabled: parseBooleanEnv(
     'BEATMAP_ATTRIBUTE_CREATION_ENABLED'
   ),
+  beatmapFileStorage: {
+    gcsBucketName: process.env.GCS_BEATMAP_BUCKET_NAME,
+    localPath:
+      process.env.BEATMAP_FILE_LOCAL_PATH ??
+      path.join(projectRoot, 'beatmap-storage'),
+  },
   playerAutoRefetch: {
     osu: playerOsuAutoRefetch,
     osuTrack: playerOsuTrackAutoRefetch,

--- a/apps/data-worker/src/env.ts
+++ b/apps/data-worker/src/env.ts
@@ -1,5 +1,5 @@
 import { loadRootEnv, projectRoot } from '../../../lib/env/load-root-env';
-import path from 'path';
+import { join } from 'path';
 
 loadRootEnv();
 
@@ -112,7 +112,7 @@ export const dataWorkerEnv = {
     gcsBucketName: process.env.GCS_BEATMAP_BUCKET_NAME,
     localPath:
       process.env.BEATMAP_FILE_LOCAL_PATH ??
-      path.join(projectRoot, 'beatmap-storage'),
+      join(projectRoot, 'beatmap-storage'),
   },
   playerAutoRefetch: {
     osu: playerOsuAutoRefetch,

--- a/apps/data-worker/src/osu/__tests__/beatmap-store.test.ts
+++ b/apps/data-worker/src/osu/__tests__/beatmap-store.test.ts
@@ -15,7 +15,7 @@ import { gzipSync, gunzipSync, file as localFile } from 'bun';
 import type { RateLimiter } from '../../rate-limiter';
 import type { Logger } from '../../logging/logger';
 
-// --- GCS mock objects ---
+// #region Mocks
 
 const mockGcsFile = {
   exists: mock(() => Promise.resolve([false] as [boolean])),
@@ -36,7 +36,7 @@ mock.module('@google-cloud/storage', () => ({
   },
 }));
 
-// --- Module under test ---
+// #endregion
 
 import {
   LocalBeatmapStorage,
@@ -45,7 +45,7 @@ import {
   beatmapFilename,
 } from '../beatmap-store';
 
-// --- Helpers ---
+// #region Helpers
 
 const passthroughLimiter = (): RateLimiter => ({
   schedule: (task) => task(),
@@ -76,12 +76,14 @@ afterEach(() => {
   beatmapId++;
 });
 
-// --- LocalBeatmapStorage ---
+// #endregion
+
+// #region LocalBeatmapStorage
 
 describe('LocalBeatmapStorage', () => {
   const directory = join(tmpdir(), `beatmap-local-${Date.now()}`);
 
-  afterAll(async () => {
+  afterAll(() => {
     rmSync(directory, { recursive: true, force: true });
   });
 
@@ -176,7 +178,9 @@ describe('LocalBeatmapStorage', () => {
   });
 });
 
-// --- GcsBeatmapStorage ---
+// #endregion
+
+// #region GcsBeatmapStorage
 
 describe('GcsBeatmapStorage', () => {
   beforeEach(() => {
@@ -303,7 +307,9 @@ describe('GcsBeatmapStorage', () => {
   });
 });
 
-// --- createBeatmapStorage ---
+// #endregion
+
+// #region createBeatmapStorage
 
 describe('createBeatmapStorage', () => {
   const directory = join(tmpdir(), `beatmap-factory-${Date.now()}`);
@@ -353,3 +359,5 @@ describe('createBeatmapStorage', () => {
     expect(storage).toBeInstanceOf(LocalBeatmapStorage);
   });
 });
+
+// #endregion

--- a/apps/data-worker/src/osu/__tests__/beatmap-store.test.ts
+++ b/apps/data-worker/src/osu/__tests__/beatmap-store.test.ts
@@ -1,0 +1,355 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from 'bun:test';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { rmSync } from 'fs';
+import { gzipSync, gunzipSync, file as localFile } from 'bun';
+import type { RateLimiter } from '../../rate-limiter';
+import type { Logger } from '../../logging/logger';
+
+// --- GCS mock objects ---
+
+const mockGcsFile = {
+  exists: mock(() => Promise.resolve([false] as [boolean])),
+  download: mock(() => Promise.resolve([Buffer.from('')] as [Buffer])),
+  save: mock((_data: unknown, _opts: unknown) => Promise.resolve()),
+};
+
+const mockGcsBucket = {
+  exists: mock(() => Promise.resolve([true] as [boolean])),
+  file: mock((_name: string) => mockGcsFile),
+};
+
+mock.module('@google-cloud/storage', () => ({
+  Storage: class {
+    bucket(_name: string) {
+      return mockGcsBucket;
+    }
+  },
+}));
+
+// --- Module under test ---
+
+import {
+  LocalBeatmapStorage,
+  GcsBeatmapStorage,
+  createBeatmapStorage,
+  beatmapFilename,
+} from '../beatmap-store';
+
+// --- Helpers ---
+
+const passthroughLimiter = (): RateLimiter => ({
+  schedule: (task) => task(),
+});
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  child: () => noopLogger,
+};
+
+type FetchSpy = ReturnType<typeof spyOn<typeof globalThis, 'fetch'>>;
+
+const sampleContent = new TextEncoder().encode('osu beatmap file content');
+
+const mockFetchResponse = (status: number, data?: ArrayBuffer) =>
+  Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    arrayBuffer: () => Promise.resolve(data ?? new ArrayBuffer(0)),
+  } as Response);
+
+let beatmapId = 1;
+
+afterEach(() => {
+  beatmapId++;
+});
+
+// --- LocalBeatmapStorage ---
+
+describe('LocalBeatmapStorage', () => {
+  const directory = join(tmpdir(), `beatmap-local-${Date.now()}`);
+
+  afterAll(async () => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  const makeStorage = (dir = directory) =>
+    new LocalBeatmapStorage({
+      directory: dir,
+      rateLimiter: passthroughLimiter(),
+      logger: noopLogger,
+    });
+
+  describe('exists()', () => {
+    it('returns false when the file has not been stored', async () => {
+      expect(await makeStorage().exists(beatmapId)).toBe(false);
+    });
+
+    it('returns true after the file has been stored', async () => {
+      const storage = makeStorage();
+      await storage.store(beatmapId, sampleContent);
+      expect(await storage.exists(beatmapId)).toBe(true);
+    });
+  });
+
+  describe('store()', () => {
+    it('writes a gzip-compressed file to disk', async () => {
+      const storage = makeStorage();
+      await storage.store(beatmapId, sampleContent);
+
+      const raw = await localFile(
+        join(directory, beatmapFilename(beatmapId))
+      ).arrayBuffer();
+      const decompressed = gunzipSync(new Uint8Array(raw));
+      expect(decompressed).toEqual(sampleContent);
+    });
+
+    it('creates the storage directory when it does not exist', async () => {
+      const nested = join(directory, 'nested', 'deep');
+      const storage = makeStorage(nested);
+      await storage.store(beatmapId, sampleContent);
+      expect(await storage.exists(beatmapId)).toBe(true);
+    });
+  });
+
+  describe('get()', () => {
+    let fetchSpy: FetchSpy;
+
+    beforeEach(() => {
+      fetchSpy = spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('returns decompressed data when the file already exists', async () => {
+      const storage = makeStorage();
+      await storage.store(beatmapId, sampleContent);
+
+      const result = await storage.get(beatmapId);
+      expect(result).toEqual(sampleContent);
+    });
+
+    it('downloads, stores, and returns data when the file is not present', async () => {
+      const storage = makeStorage();
+      fetchSpy.mockReturnValue(mockFetchResponse(200, sampleContent.buffer));
+
+      const result = await storage.get(beatmapId);
+      expect(result).toEqual(sampleContent);
+      expect(await storage.exists(beatmapId)).toBe(true);
+    });
+
+    it('returns an empty buffer when download was unsuccessful', async () => {
+      const storage = makeStorage();
+      fetchSpy.mockReturnValue(mockFetchResponse(404));
+
+      const result = await storage.get(beatmapId);
+      expect(result.byteLength).toBe(0);
+    });
+
+    it('stores an empty placeholder file when download was unsuccessful', async () => {
+      const storage = makeStorage();
+      fetchSpy.mockReturnValue(mockFetchResponse(404));
+
+      const result = await storage.get(beatmapId);
+      const raw = await localFile(
+        join(directory, beatmapFilename(beatmapId))
+      ).arrayBuffer();
+      const decompressed = gunzipSync(new Uint8Array(raw));
+
+      expect(result.byteLength).toBe(0);
+      expect(decompressed.byteLength).toBe(0);
+    });
+  });
+});
+
+// --- GcsBeatmapStorage ---
+
+describe('GcsBeatmapStorage', () => {
+  beforeEach(() => {
+    mockGcsFile.exists.mockReset();
+    mockGcsFile.download.mockReset();
+    mockGcsFile.save.mockReset();
+    mockGcsBucket.exists.mockReset();
+    mockGcsBucket.file.mockReset();
+    mockGcsBucket.file.mockImplementation(() => mockGcsFile);
+  });
+
+  const makeStorage = () =>
+    new GcsBeatmapStorage({
+      bucketName: 'test-bucket',
+      rateLimiter: passthroughLimiter(),
+      logger: noopLogger,
+    });
+
+  describe('exists()', () => {
+    it('returns true when the file exists in GCS', async () => {
+      mockGcsFile.exists.mockResolvedValue([true] as [boolean]);
+      expect(await makeStorage().exists(beatmapId)).toBe(true);
+    });
+
+    it('returns false when the file does not exist in GCS', async () => {
+      mockGcsFile.exists.mockResolvedValue([false] as [boolean]);
+      expect(await makeStorage().exists(beatmapId)).toBe(false);
+    });
+  });
+
+  describe('store()', () => {
+    it('saves a gzip-compressed file to GCS with the correct content type', async () => {
+      mockGcsFile.save.mockResolvedValue(undefined);
+
+      await makeStorage().store(beatmapId, sampleContent);
+
+      expect(mockGcsFile.save).toHaveBeenCalledTimes(1);
+      const [savedData, savedOpts] = mockGcsFile.save.mock.calls[0] as [
+        Uint8Array,
+        { contentType: string },
+      ];
+      expect(savedOpts).toEqual({ contentType: 'application/gzip' });
+      expect(gunzipSync(new Uint8Array(savedData))).toEqual(sampleContent);
+    });
+
+    it('uses the filename derived from the beatmapId', async () => {
+      mockGcsFile.save.mockResolvedValue(undefined);
+      await makeStorage().store(beatmapId, sampleContent);
+      expect(mockGcsBucket.file).toHaveBeenCalledWith(
+        beatmapFilename(beatmapId)
+      );
+    });
+  });
+
+  describe('get()', () => {
+    let fetchSpy: FetchSpy;
+
+    beforeEach(() => {
+      fetchSpy = spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('decompresses and returns data when the file is already in GCS', async () => {
+      const compressed = gzipSync(sampleContent);
+      mockGcsFile.exists.mockResolvedValue([true] as [boolean]);
+      mockGcsFile.download.mockResolvedValue([Buffer.from(compressed)] as [
+        Buffer,
+      ]);
+
+      const result = await makeStorage().get(beatmapId);
+      expect(result).toEqual(sampleContent);
+    });
+
+    it('downloads from osu!, stores to GCS, and returns raw data when not cached', async () => {
+      mockGcsFile.exists.mockResolvedValue([false] as [boolean]);
+      mockGcsFile.save.mockResolvedValue(undefined);
+      fetchSpy.mockReturnValue(mockFetchResponse(200, sampleContent.buffer));
+
+      const result = await makeStorage().get(beatmapId);
+      expect(result).toEqual(sampleContent);
+      expect(mockGcsFile.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('create()', () => {
+    it('returns a GcsBeatmapStorage instance when the bucket exists', async () => {
+      mockGcsBucket.exists.mockResolvedValue([true] as [boolean]);
+
+      const instance = await GcsBeatmapStorage.create({
+        bucketName: 'valid-bucket',
+        rateLimiter: passthroughLimiter(),
+        logger: noopLogger,
+      });
+
+      expect(instance).toBeInstanceOf(GcsBeatmapStorage);
+    });
+
+    it('throws when the bucket does not exist', async () => {
+      mockGcsBucket.exists.mockResolvedValue([false] as [boolean]);
+
+      expect(
+        GcsBeatmapStorage.create({
+          bucketName: 'missing-bucket',
+          rateLimiter: passthroughLimiter(),
+          logger: noopLogger,
+        })
+      ).rejects.toThrow();
+    });
+
+    it('throws when GCS credentials are unavailable', async () => {
+      mockGcsBucket.exists.mockRejectedValue(new Error('UNAUTHENTICATED'));
+
+      expect(
+        GcsBeatmapStorage.create({
+          bucketName: 'test-bucket',
+          rateLimiter: passthroughLimiter(),
+          logger: noopLogger,
+        })
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// --- createBeatmapStorage ---
+
+describe('createBeatmapStorage', () => {
+  const directory = join(tmpdir(), `beatmap-factory-${Date.now()}`);
+
+  afterAll(async () => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    mockGcsBucket.exists.mockReset();
+    mockGcsBucket.file.mockReset();
+    mockGcsBucket.file.mockImplementation(() => mockGcsFile);
+  });
+
+  it('creates a LocalBeatmapStorage when no bucket name is provided', async () => {
+    const storage = await createBeatmapStorage({
+      directory,
+      rateLimiter: passthroughLimiter(),
+      logger: noopLogger,
+    });
+    expect(storage).toBeInstanceOf(LocalBeatmapStorage);
+  });
+
+  it('creates a GcsBeatmapStorage when a bucket name is provided and GCS is reachable', async () => {
+    mockGcsBucket.exists.mockResolvedValue([true] as [boolean]);
+
+    const storage = await createBeatmapStorage({
+      directory,
+      bucketName: 'valid-bucket',
+      rateLimiter: passthroughLimiter(),
+      logger: noopLogger,
+    });
+
+    expect(storage).toBeInstanceOf(GcsBeatmapStorage);
+  });
+
+  it('falls back to LocalBeatmapStorage and logs a warning when GCS is unavailable', async () => {
+    mockGcsBucket.exists.mockResolvedValue([false] as [boolean]);
+
+    const storage = await createBeatmapStorage({
+      directory,
+      bucketName: 'bad-bucket',
+      rateLimiter: passthroughLimiter(),
+      logger: noopLogger,
+    });
+
+    expect(storage).toBeInstanceOf(LocalBeatmapStorage);
+  });
+});

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -5,8 +5,9 @@ import { Ruleset } from '@otr/core/osu/enums';
 import { Storage } from '@google-cloud/storage';
 import type { Logger } from '../logging/logger';
 import type { RateLimiter } from '../rate-limiter';
-import fs from 'fs';
-import path from 'path';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { gzipSync, gunzipSync, file as localFile } from 'bun';
 
 type QueryExecutor = Pick<DatabaseClient, 'query' | 'insert' | 'update'>;
 type UpdateExecutor = Pick<DatabaseClient, 'update'>;
@@ -231,12 +232,12 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
 
     // Download and decompress beatmap file
     const [data] = await file.download();
-    return Bun.gunzipSync(new Uint8Array(data));
+    return gunzipSync(new Uint8Array(data));
   }
 
   async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
     // Compress before storing
-    const compressed = Bun.gzipSync(data);
+    const compressed = gzipSync(data);
 
     await this.storage
       .bucket(this.bucketName)
@@ -269,11 +270,11 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
   }
 
   private filepath(beatmapId: number) {
-    return path.join(this.directory, filename(beatmapId));
+    return join(this.directory, filename(beatmapId));
   }
 
   async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
-    const file = Bun.file(this.filepath(beatmapId));
+    const file = localFile(this.filepath(beatmapId));
 
     // Download and store
     if (!(await file.exists())) {
@@ -289,14 +290,14 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
 
   async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
     // Ensure local storage dir
-    fs.mkdirSync(this.directory, { recursive: true });
+    mkdirSync(this.directory, { recursive: true });
 
     // Compress with gzip and store
     await Bun.write(this.filepath(beatmapId), Bun.gzipSync(data));
   }
 
   async exists(beatmapId: number): Promise<boolean> {
-    return Bun.file(this.filepath(beatmapId)).exists();
+    return localFile(this.filepath(beatmapId)).exists();
   }
 }
 

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -1,8 +1,12 @@
 import { eq } from 'drizzle-orm';
-
 import type { DatabaseClient } from '../db';
 import * as schema from '@otr/core/db/schema';
 import { Ruleset } from '@otr/core/osu/enums';
+import { Storage } from '@google-cloud/storage';
+import type { Logger } from '../logging/logger';
+import type { RateLimiter } from '../rate-limiter';
+import fs from 'fs';
+import path from 'path';
 
 type QueryExecutor = Pick<DatabaseClient, 'query' | 'insert' | 'update'>;
 type UpdateExecutor = Pick<DatabaseClient, 'update'>;
@@ -92,3 +96,244 @@ export const updateBeatmapStatus = async (
     })
     .where(eq(schema.beatmaps.id, beatmapId));
 };
+
+const filename = (beatmapId: number) => `${beatmapId}.osu.gz`;
+
+export interface BeatmapStorage {
+  /**
+   * Gets a beatmap file from storage.
+   * @param beatmapId Beatmap id.
+   * @returns Beatmap file data. If the file could not be downloaded, the buffer will be empty.
+   */
+  get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
+
+  /**
+   * Stores a beatmap file.
+   * @param beatmapId Beatmap id.
+   * @param data Beatmap file data.
+   */
+  store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void>;
+
+  /**
+   * Checks for the existence of a beatmap file.
+   * @param beatmapId Beatmap id.
+   */
+  exists(beatmapId: number): Promise<boolean>;
+}
+
+interface BeatmapStorageBaseOptions {
+  rateLimiter: RateLimiter;
+  logger: Logger;
+}
+
+abstract class BeatmapStorageBase implements BeatmapStorage {
+  private readonly rateLimiter: RateLimiter;
+  private readonly logger: Logger;
+
+  constructor({ rateLimiter, logger }: BeatmapStorageBaseOptions) {
+    this.rateLimiter = rateLimiter;
+    this.logger = logger;
+  }
+
+  /**
+   * Downloads a beatmap file from osu!
+   * @param beatmapId Beatmap id.
+   * @returns Beatmap file data. If download was unsuccessful, the buffer will be empty.
+   */
+  protected async download(
+    beatmapId: number
+  ): Promise<Uint8Array<ArrayBuffer>> {
+    return await this.rateLimiter.schedule(async () => {
+      const response = await fetch(`https://osu.ppy.sh/osu/${beatmapId}`);
+
+      if (response.status === 404) {
+        this.logger.warn('Beatmap file not found', {
+          beatmapId,
+        });
+        return new Uint8Array();
+      }
+
+      if (!response.ok) {
+        this.logger.error('Failed to download beatmap file', {
+          beatmapId,
+          status: response.status,
+        });
+        return new Uint8Array();
+      }
+
+      return new Uint8Array(await response.arrayBuffer());
+    });
+  }
+
+  abstract get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
+
+  abstract store(
+    beatmapId: number,
+    data: Uint8Array<ArrayBuffer>
+  ): Promise<void>;
+
+  abstract exists(beatmapId: number): Promise<boolean>;
+}
+
+interface GcsBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+  bucketName: string;
+}
+
+export class GcsBeatmapStorage extends BeatmapStorageBase {
+  private readonly storage: Storage;
+  private readonly bucketName: string;
+
+  constructor({ bucketName, ...base }: GcsBeatmapStorageOptions) {
+    super(base);
+    this.bucketName = bucketName;
+    this.storage = new Storage();
+  }
+
+  /**
+   * Creates an instance of {@link GcsBeatmapStorage} and ensures access to the target GCS bucket.
+   * @param options Beatmap storage options.
+   * @returns An instance of {@link GcsBeatmapStorage}.
+   */
+  static async create(
+    options: GcsBeatmapStorageOptions
+  ): Promise<GcsBeatmapStorage> {
+    const instance = new GcsBeatmapStorage(options);
+    let exists = false;
+
+    try {
+      [exists] = await instance.storage.bucket(options.bucketName).exists();
+    } catch {
+      throw new Error(
+        `Could not access GCS bucket. Check the GOOGLE_APPLICATION_CREDENTIALS environment variable.`
+      );
+    }
+
+    if (!exists) {
+      throw new Error(
+        `GCS bucket "${options.bucketName}" does not exist or is inaccessible.`
+      );
+    }
+
+    return instance;
+  }
+
+  async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
+    const file = this.storage.bucket(this.bucketName).file(filename(beatmapId));
+    const [exists] = await file.exists();
+
+    // Download and store
+    if (!exists) {
+      const downloaded = await this.download(beatmapId);
+      await this.store(beatmapId, downloaded);
+
+      return downloaded;
+    }
+
+    // Download and decompress beatmap file
+    const [data] = await file.download();
+    return Bun.gunzipSync(new Uint8Array(data));
+  }
+
+  async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
+    // Compress before storing
+    const compressed = Bun.gzipSync(data);
+
+    await this.storage
+      .bucket(this.bucketName)
+      .file(filename(beatmapId))
+      .save(compressed, {
+        contentType: 'application/gzip',
+      });
+  }
+
+  async exists(beatmapId: number): Promise<boolean> {
+    const [exists] = await this.storage
+      .bucket(this.bucketName)
+      .file(filename(beatmapId))
+      .exists();
+
+    return exists;
+  }
+}
+
+interface LocalBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+  directory: string;
+}
+
+export class LocalBeatmapStorage extends BeatmapStorageBase {
+  private readonly directory: string;
+
+  constructor({ directory, ...base }: LocalBeatmapStorageOptions) {
+    super(base);
+    this.directory = directory;
+  }
+
+  private filepath(beatmapId: number) {
+    return path.join(this.directory, filename(beatmapId));
+  }
+
+  async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
+    const file = Bun.file(this.filepath(beatmapId));
+
+    // Download and store
+    if (!(await file.exists())) {
+      const downloaded = await this.download(beatmapId);
+      await this.store(beatmapId, downloaded);
+
+      return downloaded;
+    }
+
+    // Decompress file data before returning
+    return Bun.gunzipSync(await file.arrayBuffer());
+  }
+
+  async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
+    // Ensure local storage dir
+    fs.mkdirSync(this.directory, { recursive: true });
+
+    // Compress with gzip and store
+    await Bun.write(this.filepath(beatmapId), Bun.gzipSync(data));
+  }
+
+  async exists(beatmapId: number): Promise<boolean> {
+    return Bun.file(this.filepath(beatmapId)).exists();
+  }
+}
+
+export type BeatmapStorageCreationOptions = LocalBeatmapStorageOptions &
+  Omit<GcsBeatmapStorageOptions, 'bucketName'> & {
+    bucketName?: string;
+  };
+
+/**
+ * Creates an instance of a {@link BeatmapStorage} implementation based on provided options.
+ *
+ * If {@link BeatmapStorageCreationOptions#bucketName} is provided, an instance of {@link GcsBeatmapStorage} will
+ * be created if possible. If not, an instance of {@link LocalBeatmapStorage} will be created as a fallback.
+ */
+export async function createBeatmapStorage({
+  rateLimiter,
+  logger,
+  bucketName,
+  directory,
+}: BeatmapStorageCreationOptions): Promise<BeatmapStorage> {
+  if (bucketName) {
+    try {
+      const storage = await GcsBeatmapStorage.create({
+        bucketName,
+        logger,
+        rateLimiter,
+      });
+      logger.info('Using GCS beatmap storage', { bucketName });
+      return storage;
+    } catch (error) {
+      logger.warn('GCS storage unavailable, falling back to local storage', {
+        error,
+        directory,
+      });
+    }
+  }
+
+  logger.info('Using local beatmap storage', { directory });
+  return new LocalBeatmapStorage({ directory, logger, rateLimiter });
+}

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -98,7 +98,9 @@ export const updateBeatmapStatus = async (
     .where(eq(schema.beatmaps.id, beatmapId));
 };
 
-const filename = (beatmapId: number) => `${beatmapId}.osu.gz`;
+// #region Beatmap file storage
+
+export const beatmapFilename = (beatmapId: number) => `${beatmapId}.osu.gz`;
 
 export interface BeatmapStorage {
   /**
@@ -219,7 +221,9 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
   }
 
   async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
-    const file = this.storage.bucket(this.bucketName).file(filename(beatmapId));
+    const file = this.storage
+      .bucket(this.bucketName)
+      .file(beatmapFilename(beatmapId));
     const [exists] = await file.exists();
 
     // Download and store
@@ -241,7 +245,7 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
 
     await this.storage
       .bucket(this.bucketName)
-      .file(filename(beatmapId))
+      .file(beatmapFilename(beatmapId))
       .save(compressed, {
         contentType: 'application/gzip',
       });
@@ -250,7 +254,7 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
   async exists(beatmapId: number): Promise<boolean> {
     const [exists] = await this.storage
       .bucket(this.bucketName)
-      .file(filename(beatmapId))
+      .file(beatmapFilename(beatmapId))
       .exists();
 
     return exists;
@@ -270,7 +274,7 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
   }
 
   private filepath(beatmapId: number) {
-    return join(this.directory, filename(beatmapId));
+    return join(this.directory, beatmapFilename(beatmapId));
   }
 
   async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
@@ -338,3 +342,5 @@ export async function createBeatmapStorage({
   logger.info('Using local beatmap storage', { directory });
   return new LocalBeatmapStorage({ directory, logger, rateLimiter });
 }
+
+// #endregion

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -12,7 +12,7 @@ import { gzipSync, gunzipSync, file as localFile } from 'bun';
 type QueryExecutor = Pick<DatabaseClient, 'query' | 'insert' | 'update'>;
 type UpdateExecutor = Pick<DatabaseClient, 'update'>;
 
-export interface BeatmapRecord {
+interface BeatmapRecord {
   id: number;
   dataFetchStatus: number;
 }
@@ -20,23 +20,23 @@ export interface BeatmapRecord {
 export interface BeatmapStorage {
   /**
    * Gets a beatmap file from storage.
-   * @param beatmapId Beatmap id.
+   * @param osuBeatmapId Beatmap id.
    * @returns Beatmap file data. If the file could not be downloaded, the buffer will be empty.
    */
-  get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
+  get(osuBeatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
 
   /**
    * Stores a beatmap file.
-   * @param beatmapId Beatmap id.
+   * @param osuBeatmapId Beatmap id.
    * @param data Beatmap file data.
    */
-  store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void>;
+  store(osuBeatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void>;
 
   /**
    * Checks for the existence of a beatmap file.
-   * @param beatmapId Beatmap id.
+   * @param osuBeatmapId Beatmap id.
    */
-  exists(beatmapId: number): Promise<boolean>;
+  exists(osuBeatmapId: number): Promise<boolean>;
 }
 
 interface BeatmapStorageBaseOptions {
@@ -125,7 +125,7 @@ export const ensureBeatmapPlaceholder = async (
 
 export const updateBeatmapStatus = async (
   db: UpdateExecutor,
-  beatmapId: number,
+  osuBeatmapId: number,
   status: number,
   updatedIso: string
 ) => {
@@ -135,12 +135,13 @@ export const updateBeatmapStatus = async (
       dataFetchStatus: status,
       updated: updatedIso,
     })
-    .where(eq(schema.beatmaps.id, beatmapId));
+    .where(eq(schema.beatmaps.id, osuBeatmapId));
 };
 
 // #region Beatmap file storage
 
-export const beatmapFilename = (beatmapId: number) => `${beatmapId}.osu.gz`;
+export const beatmapFilename = (osuBeatmapId: number) =>
+  `${osuBeatmapId}.osu.gz`;
 
 abstract class BeatmapStorageBase implements BeatmapStorage {
   private readonly rateLimiter: RateLimiter;
@@ -153,25 +154,25 @@ abstract class BeatmapStorageBase implements BeatmapStorage {
 
   /**
    * Downloads a beatmap file from osu!
-   * @param beatmapId Beatmap id.
+   * @param osuBeatmapId Beatmap id.
    * @returns Beatmap file data. If download was unsuccessful, the buffer will be empty.
    */
   protected async download(
-    beatmapId: number
+    osuBeatmapId: number
   ): Promise<Uint8Array<ArrayBuffer>> {
     return await this.rateLimiter.schedule(async () => {
-      const response = await fetch(`https://osu.ppy.sh/osu/${beatmapId}`);
+      const response = await fetch(`https://osu.ppy.sh/osu/${osuBeatmapId}`);
 
       if (response.status === 404) {
         this.logger.warn('Beatmap file not found', {
-          beatmapId,
+          osuBeatmapId,
         });
         return new Uint8Array();
       }
 
       if (!response.ok) {
         this.logger.error('Failed to download beatmap file', {
-          beatmapId,
+          osuBeatmapId,
           status: response.status,
         });
         return new Uint8Array();
@@ -181,14 +182,14 @@ abstract class BeatmapStorageBase implements BeatmapStorage {
     });
   }
 
-  abstract get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
+  abstract get(osuBeatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
 
   abstract store(
-    beatmapId: number,
+    osuBeatmapId: number,
     data: Uint8Array<ArrayBuffer>
   ): Promise<void>;
 
-  abstract exists(beatmapId: number): Promise<boolean>;
+  abstract exists(osuBeatmapId: number): Promise<boolean>;
 }
 
 export class GcsBeatmapStorage extends BeatmapStorageBase {
@@ -229,16 +230,16 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
     return instance;
   }
 
-  async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
+  async get(osuBeatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
     const file = this.storage
       .bucket(this.bucketName)
-      .file(beatmapFilename(beatmapId));
+      .file(beatmapFilename(osuBeatmapId));
     const [exists] = await file.exists();
 
     // Download and store
     if (!exists) {
-      const downloaded = await this.download(beatmapId);
-      await this.store(beatmapId, downloaded);
+      const downloaded = await this.download(osuBeatmapId);
+      await this.store(osuBeatmapId, downloaded);
 
       return downloaded;
     }
@@ -248,22 +249,25 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
     return gunzipSync(new Uint8Array(data));
   }
 
-  async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
+  async store(
+    osuBeatmapId: number,
+    data: Uint8Array<ArrayBuffer>
+  ): Promise<void> {
     // Compress before storing
     const compressed = gzipSync(data);
 
     await this.storage
       .bucket(this.bucketName)
-      .file(beatmapFilename(beatmapId))
+      .file(beatmapFilename(osuBeatmapId))
       .save(compressed, {
         contentType: 'application/gzip',
       });
   }
 
-  async exists(beatmapId: number): Promise<boolean> {
+  async exists(osuBeatmapId: number): Promise<boolean> {
     const [exists] = await this.storage
       .bucket(this.bucketName)
-      .file(beatmapFilename(beatmapId))
+      .file(beatmapFilename(osuBeatmapId))
       .exists();
 
     return exists;
@@ -278,17 +282,17 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
     this.directory = directory;
   }
 
-  private filepath(beatmapId: number) {
-    return join(this.directory, beatmapFilename(beatmapId));
+  private filepath(osuBeatmapId: number) {
+    return join(this.directory, beatmapFilename(osuBeatmapId));
   }
 
-  async get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
-    const file = localFile(this.filepath(beatmapId));
+  async get(osuBeatmapId: number): Promise<Uint8Array<ArrayBuffer>> {
+    const file = localFile(this.filepath(osuBeatmapId));
 
     // Download and store
     if (!(await file.exists())) {
-      const downloaded = await this.download(beatmapId);
-      await this.store(beatmapId, downloaded);
+      const downloaded = await this.download(osuBeatmapId);
+      await this.store(osuBeatmapId, downloaded);
 
       return downloaded;
     }
@@ -297,16 +301,19 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
     return Bun.gunzipSync(await file.arrayBuffer());
   }
 
-  async store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void> {
+  async store(
+    osuBeatmapId: number,
+    data: Uint8Array<ArrayBuffer>
+  ): Promise<void> {
     // Ensure local storage dir
     mkdirSync(this.directory, { recursive: true });
 
     // Compress with gzip and store
-    await Bun.write(this.filepath(beatmapId), Bun.gzipSync(data));
+    await Bun.write(this.filepath(osuBeatmapId), Bun.gzipSync(data));
   }
 
-  async exists(beatmapId: number): Promise<boolean> {
-    return localFile(this.filepath(beatmapId)).exists();
+  async exists(osuBeatmapId: number): Promise<boolean> {
+    return localFile(this.filepath(osuBeatmapId)).exists();
   }
 }
 

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -17,6 +17,46 @@ export interface BeatmapRecord {
   dataFetchStatus: number;
 }
 
+export interface BeatmapStorage {
+  /**
+   * Gets a beatmap file from storage.
+   * @param beatmapId Beatmap id.
+   * @returns Beatmap file data. If the file could not be downloaded, the buffer will be empty.
+   */
+  get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
+
+  /**
+   * Stores a beatmap file.
+   * @param beatmapId Beatmap id.
+   * @param data Beatmap file data.
+   */
+  store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void>;
+
+  /**
+   * Checks for the existence of a beatmap file.
+   * @param beatmapId Beatmap id.
+   */
+  exists(beatmapId: number): Promise<boolean>;
+}
+
+interface BeatmapStorageBaseOptions {
+  rateLimiter: RateLimiter;
+  logger: Logger;
+}
+
+interface GcsBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+  bucketName: string;
+}
+
+interface LocalBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+  directory: string;
+}
+
+export type BeatmapStorageCreationOptions = LocalBeatmapStorageOptions &
+  Omit<GcsBeatmapStorageOptions, 'bucketName'> & {
+    bucketName?: string;
+  };
+
 export const ensureBeatmapPlaceholder = async (
   db: QueryExecutor,
   osuBeatmapId: number,
@@ -102,33 +142,6 @@ export const updateBeatmapStatus = async (
 
 export const beatmapFilename = (beatmapId: number) => `${beatmapId}.osu.gz`;
 
-export interface BeatmapStorage {
-  /**
-   * Gets a beatmap file from storage.
-   * @param beatmapId Beatmap id.
-   * @returns Beatmap file data. If the file could not be downloaded, the buffer will be empty.
-   */
-  get(beatmapId: number): Promise<Uint8Array<ArrayBuffer>>;
-
-  /**
-   * Stores a beatmap file.
-   * @param beatmapId Beatmap id.
-   * @param data Beatmap file data.
-   */
-  store(beatmapId: number, data: Uint8Array<ArrayBuffer>): Promise<void>;
-
-  /**
-   * Checks for the existence of a beatmap file.
-   * @param beatmapId Beatmap id.
-   */
-  exists(beatmapId: number): Promise<boolean>;
-}
-
-interface BeatmapStorageBaseOptions {
-  rateLimiter: RateLimiter;
-  logger: Logger;
-}
-
 abstract class BeatmapStorageBase implements BeatmapStorage {
   private readonly rateLimiter: RateLimiter;
   private readonly logger: Logger;
@@ -176,10 +189,6 @@ abstract class BeatmapStorageBase implements BeatmapStorage {
   ): Promise<void>;
 
   abstract exists(beatmapId: number): Promise<boolean>;
-}
-
-interface GcsBeatmapStorageOptions extends BeatmapStorageBaseOptions {
-  bucketName: string;
 }
 
 export class GcsBeatmapStorage extends BeatmapStorageBase {
@@ -261,10 +270,6 @@ export class GcsBeatmapStorage extends BeatmapStorageBase {
   }
 }
 
-interface LocalBeatmapStorageOptions extends BeatmapStorageBaseOptions {
-  directory: string;
-}
-
 export class LocalBeatmapStorage extends BeatmapStorageBase {
   private readonly directory: string;
 
@@ -304,11 +309,6 @@ export class LocalBeatmapStorage extends BeatmapStorageBase {
     return localFile(this.filepath(beatmapId)).exists();
   }
 }
-
-export type BeatmapStorageCreationOptions = LocalBeatmapStorageOptions &
-  Omit<GcsBeatmapStorageOptions, 'bucketName'> & {
-    bucketName?: string;
-  };
 
 /**
  * Creates an instance of a {@link BeatmapStorage} implementation based on provided options.

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -44,18 +44,18 @@ interface BeatmapStorageBaseOptions {
   logger: Logger;
 }
 
-interface GcsBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+export interface GcsBeatmapStorageOptions extends BeatmapStorageBaseOptions {
   bucketName: string;
 }
 
-interface LocalBeatmapStorageOptions extends BeatmapStorageBaseOptions {
+export interface LocalBeatmapStorageOptions extends BeatmapStorageBaseOptions {
   directory: string;
 }
 
-export type BeatmapStorageCreationOptions = LocalBeatmapStorageOptions &
-  Omit<GcsBeatmapStorageOptions, 'bucketName'> & {
-    bucketName?: string;
-  };
+export type BeatmapStorageCreationOptions = BeatmapStorageBaseOptions & {
+  bucketName?: string;
+  directory: string;
+};
 
 export const ensureBeatmapPlaceholder = async (
   db: QueryExecutor,

--- a/apps/data-worker/src/osu/beatmap-store.ts
+++ b/apps/data-worker/src/osu/beatmap-store.ts
@@ -125,7 +125,7 @@ export const ensureBeatmapPlaceholder = async (
 
 export const updateBeatmapStatus = async (
   db: UpdateExecutor,
-  osuBeatmapId: number,
+  beatmapId: number,
   status: number,
   updatedIso: string
 ) => {
@@ -135,7 +135,7 @@ export const updateBeatmapStatus = async (
       dataFetchStatus: status,
       updated: updatedIso,
     })
-    .where(eq(schema.beatmaps.id, osuBeatmapId));
+    .where(eq(schema.beatmaps.id, beatmapId));
 };
 
 // #region Beatmap file storage

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
     "apps/data-worker": {
       "name": "data-worker",
       "dependencies": {
+        "@google-cloud/storage": "^7.19.0",
         "@otr/core": "workspace:*",
         "amqplib": "^0.10.4",
         "drizzle-orm": "^0.44.5",
@@ -473,6 +474,14 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, ""],
 
+    "@google-cloud/paginator": ["@google-cloud/paginator@5.0.2", "", { "dependencies": { "arrify": "^2.0.0", "extend": "^3.0.2" } }, "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg=="],
+
+    "@google-cloud/projectify": ["@google-cloud/projectify@4.0.0", "", {}, "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA=="],
+
+    "@google-cloud/promisify": ["@google-cloud/promisify@4.0.0", "", {}, "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="],
+
+    "@google-cloud/storage": ["@google-cloud/storage@7.19.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0", "uuid": "^8.0.0" } }, "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ=="],
+
     "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@4.1.3", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.0.0" } }, ""],
@@ -801,9 +810,13 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.12", "", {}, "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA=="],
 
+    "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
+
     "@trysound/sax": ["@trysound/sax@0.2.0", "", {}, ""],
 
     "@types/amqplib": ["@types/amqplib@0.10.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA=="],
+
+    "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.1", "", {}, ""],
 
@@ -837,6 +850,10 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/request": ["@types/request@2.48.13", "", { "dependencies": { "@types/caseless": "*", "@types/node": "*", "@types/tough-cookie": "*", "form-data": "^2.5.5" } }, "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.33.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.33.0", "@typescript-eslint/type-utils": "8.33.0", "@typescript-eslint/utils": "8.33.0", "@typescript-eslint/visitor-keys": "8.33.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.33.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, ""],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.33.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.33.0", "@typescript-eslint/types": "8.33.0", "@typescript-eslint/typescript-estree": "8.33.0", "@typescript-eslint/visitor-keys": "8.33.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, ""],
@@ -863,9 +880,13 @@
 
     "@unrs/resolver-binding-linux-x64-musl": ["@unrs/resolver-binding-linux-x64-musl@1.7.8", "", { "os": "linux", "cpu": "x64" }, ""],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, ""],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, ""],
 
@@ -897,11 +918,15 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, ""],
 
+    "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
+
     "asn1js": ["asn1js@3.0.6", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, ""],
 
     "async-function": ["async-function@1.0.0", "", {}, ""],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -923,9 +948,13 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, ""],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "better-auth": ["better-auth@1.3.8", "", { "dependencies": { "@better-auth/utils": "0.2.6", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.8.0", "@simplewebauthn/browser": "^13.1.2", "@simplewebauthn/server": "^13.1.2", "better-call": "1.0.16", "defu": "^6.1.4", "jose": "^5.10.0", "kysely": "^0.28.5", "nanostores": "^0.11.4", "zod": "^4.1.5" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-uRFzHbWkhr8eWNy+BJwyMnrZPOvQjwrcLND3nc6jusRteYA9cjeRGElgCPTWTIyWUfzaQ708Lb5Mdq9Gv41Qpw=="],
 
     "better-call": ["better-call@1.0.16", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-42dgJ1rOtc0anOoxjXPOWuel/Z/4aeO7EJ2SiXNwvlkySSgjXhNjAjTMWa8DL1nt6EXS3jl3VKC3mPsU/lUgVA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "bintrees": ["bintrees@1.0.2", "", {}, "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="],
 
@@ -936,6 +965,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, ""],
 
     "browserslist": ["browserslist@4.25.0", "", { "dependencies": { "caniuse-lite": "^1.0.30001718", "electron-to-chromium": "^1.5.160", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": "cli.js" }, ""],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -1087,9 +1118,15 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, ""],
 
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.161", "", {}, ""],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, ""],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
 
@@ -1153,7 +1190,11 @@
 
     "esutils": ["esutils@2.0.3", "", {}, ""],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, ""],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, ""],
 
@@ -1164,6 +1205,10 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, ""],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, ""],
+
+    "fast-xml-builder": ["fast-xml-builder@1.0.0", "", {}, "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.4.1", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, ""],
 
@@ -1195,6 +1240,10 @@
 
     "functions-have-names": ["functions-have-names@1.2.3", "", {}, ""],
 
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+
     "gensync": ["gensync@1.0.0-beta.2", "", {}, ""],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, ""],
@@ -1213,11 +1262,17 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, ""],
 
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
     "gopd": ["gopd@1.2.0", "", {}, ""],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, ""],
 
     "graphemer": ["graphemer@1.4.0", "", {}, ""],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "h3": ["h3@1.15.4", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.2", "radix3": "^1.1.2", "ufo": "^1.6.1", "uncrypto": "^0.1.3" } }, "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ=="],
 
@@ -1235,6 +1290,12 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, ""],
 
+    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "husky": ["husky@9.1.7", "", { "bin": "bin.js" }, ""],
 
     "ignore": ["ignore@5.3.2", "", {}, ""],
@@ -1242,6 +1303,8 @@
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, ""],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, ""],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, ""],
 
@@ -1291,6 +1354,8 @@
 
     "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, ""],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, ""],
 
     "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, ""],
@@ -1319,6 +1384,8 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": "bin/jsesc" }, ""],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, ""],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, ""],
@@ -1330,6 +1397,10 @@
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, ""],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, ""],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, ""],
 
@@ -1393,6 +1464,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, ""],
 
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -1420,6 +1493,8 @@
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, ""],
 
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, ""],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
@@ -1450,6 +1525,8 @@
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
@@ -1569,6 +1646,8 @@
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, ""],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, ""],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
@@ -1599,6 +1678,10 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, ""],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
+
     "reusify": ["reusify@1.1.0", "", {}, ""],
 
     "rou3": ["rou3@0.7.3", "", {}, "sha512-KKenF/hB2iIhS1ohj226LT+/8uKCBpSMqeS4V1UPN9vad99uLoyIhrULRRB1skaB40LQHcBlSsAi3sT8MaoDDQ=="],
@@ -1606,6 +1689,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, ""],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, ""],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, ""],
 
@@ -1657,6 +1742,10 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, ""],
 
+    "stream-events": ["stream-events@1.0.5", "", { "dependencies": { "stubs": "^3.0.0" } }, "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg=="],
+
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, ""],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, ""],
@@ -1669,9 +1758,15 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, ""],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-bom": ["strip-bom@3.0.0", "", {}, ""],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, ""],
+
+    "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
+
+    "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, ""],
 
@@ -1695,6 +1790,8 @@
 
     "tdigest": ["tdigest@0.1.2", "", { "dependencies": { "bintrees": "1.0.2" } }, "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA=="],
 
+    "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
+
     "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, ""],
@@ -1702,6 +1799,8 @@
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, ""],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, ""],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, ""],
 
@@ -1755,9 +1854,17 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.5.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, ""],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, ""],
 
     "web": ["web@workspace:apps/web"],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, ""],
 
@@ -1772,6 +1879,8 @@
     "wildcard-match": ["wildcard-match@5.1.4", "", {}, "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, ""],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -1843,6 +1952,8 @@
 
     "@types/pg/@types/node": ["@types/node@20.17.57", "", { "dependencies": { "undici-types": "~6.19.2" } }, ""],
 
+    "@types/request/form-data": ["form-data@2.5.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, ""],
 
     "@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, ""],
@@ -1879,6 +1990,10 @@
 
     "fdir/picomatch": ["picomatch@4.0.2", "", {}, ""],
 
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "is-bun-module/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, ""],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, ""],
@@ -1888,6 +2003,10 @@
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": "bin/jsesc" }, ""],
 
     "sharp/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, ""],
+
+    "teeny-request/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "teeny-request/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, ""],
 
@@ -1962,5 +2081,7 @@
     "cmdk/@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, ""],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, ""],
+
+    "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
   }
 }

--- a/lib/env/load-root-env.ts
+++ b/lib/env/load-root-env.ts
@@ -2,7 +2,7 @@ import { config as loadEnv } from 'dotenv';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 
-const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
+export const projectRoot = fileURLToPath(new URL('../../', import.meta.url));
 let envLoaded = false;
 
 export function loadRootEnv(): void {


### PR DESCRIPTION
Implements a `BeatmapStorage` interface for downloading and storing beatmap files. Beatmap files are downloaded, compressed using gzip, and stored locally or in a GCS bucket.

- Adds the `GcsBeatmapStorage` class that serves as the default implementation. Files downloaded are stored permanently in a configured GCS bucket.
- Adds the `LocalBeatmapStorage` class that serves as a fallback to `GcsBeatmapStorage` or for local development. Downloaded files are stored on the host machine to a configured directory.
- Unit test coverage for both implementation as well as other added utilities.

Closes #747