### PR TITLE
Add non-verified tournaments to beatmap page/dropdowns

### DIFF
--- a/apps/web/app/server/oRPC/procedures/beatmapProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/beatmapProcedures.ts
@@ -168,13 +168,7 @@ export const getBeatmapStats = publicProcedure
             )
           )
           .where(
-            and(
-              eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId),
-              eq(
-                schema.tournaments.verificationStatus,
-                VerificationStatus.Verified
-              )
-            )
+            eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId)
           ),
         context.db
           .select({
@@ -247,13 +241,7 @@ export const getBeatmapStats = publicProcedure
             )
           )
           .where(
-            and(
-              eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId),
-              eq(
-                schema.tournaments.verificationStatus,
-                VerificationStatus.Verified
-              )
-            )
+            eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId)
           )
           .groupBy(
             schema.tournaments.id,

--- a/apps/web/app/server/oRPC/procedures/beatmapProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/beatmapProcedures.ts
@@ -167,9 +167,7 @@ export const getBeatmapStats = publicProcedure
               schema.joinPooledBeatmaps.tournamentsPooledInId
             )
           )
-          .where(
-            eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId)
-          ),
+          .where(eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId)),
         context.db
           .select({
             quarter: sql<string>`TO_CHAR(${schema.games.startTime}, 'YYYY-"Q"Q')`,
@@ -240,9 +238,7 @@ export const getBeatmapStats = publicProcedure
               eq(schema.games.verificationStatus, VerificationStatus.Verified)
             )
           )
-          .where(
-            eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId)
-          )
+          .where(eq(schema.joinPooledBeatmaps.pooledBeatmapsId, beatmapId))
           .groupBy(
             schema.tournaments.id,
             schema.tournaments.name,

--- a/apps/web/app/server/oRPC/procedures/playerProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/playerProcedures.ts
@@ -532,10 +532,6 @@ export const getPlayerBeatmaps = publicProcedure
       .where(
         and(
           eq(schema.joinBeatmapCreators.creatorsId, playerId),
-          eq(
-            schema.tournaments.verificationStatus,
-            VerificationStatus.Verified
-          ),
           // Filter by the tournament ruleset because mania variants reuse the same
           // beatmap ruleset (e.g., 4k/7k both map back to Mania = 3).
           input.ruleset != null
@@ -561,22 +557,13 @@ export const getPlayerBeatmaps = publicProcedure
     }
 
     const tournamentCountExpr = sql<number>`(
-      SELECT COUNT(DISTINCT tournament_id) FROM (
-        SELECT jpb.tournaments_pooled_in_id AS tournament_id
-        FROM join_pooled_beatmaps jpb
-        INNER JOIN tournaments t ON t.id = jpb.tournaments_pooled_in_id
-        WHERE jpb.pooled_beatmaps_id = ${schema.beatmaps.id}
-          AND t.verification_status = ${VerificationStatus.Verified}
-        UNION
-        SELECT t.id AS tournament_id
-        FROM games g
-        INNER JOIN matches m ON m.id = g.match_id
-        INNER JOIN tournaments t ON t.id = m.tournament_id
-        WHERE g.beatmap_id = ${schema.beatmaps.id}
-          AND t.verification_status = ${VerificationStatus.Verified}
-          AND m.verification_status = ${VerificationStatus.Verified}
-          AND g.verification_status = ${VerificationStatus.Verified}
-      ) AS combined_tournaments
+      SELECT COUNT(DISTINCT jpb.tournaments_pooled_in_id)
+      FROM join_pooled_beatmaps jpb
+      INNER JOIN tournaments t ON t.id = jpb.tournaments_pooled_in_id
+      WHERE jpb.pooled_beatmaps_id = ${schema.beatmaps.id}
+        ${input.ruleset != null
+          ? sql`AND t.ruleset = ${input.ruleset}`
+          : sql``}
     )`;
     const gameCountExpr = sql<number>`(
       SELECT COUNT(g.id)
@@ -584,9 +571,12 @@ export const getPlayerBeatmaps = publicProcedure
       INNER JOIN matches m ON m.id = g.match_id
       INNER JOIN tournaments t ON t.id = m.tournament_id
       WHERE g.beatmap_id = ${schema.beatmaps.id}
-        AND t.verification_status = ${VerificationStatus.Verified}
-        AND m.verification_status = ${VerificationStatus.Verified}
         AND g.verification_status = ${VerificationStatus.Verified}
+        AND m.verification_status = ${VerificationStatus.Verified}
+        AND t.verification_status = ${VerificationStatus.Verified}
+        ${input.ruleset != null
+          ? sql`AND t.ruleset = ${input.ruleset}`
+          : sql``}
     )`;
 
     const beatmapOrderingRows = await context.db
@@ -615,10 +605,6 @@ export const getPlayerBeatmaps = publicProcedure
       .where(
         and(
           eq(schema.joinBeatmapCreators.creatorsId, playerId),
-          eq(
-            schema.tournaments.verificationStatus,
-            VerificationStatus.Verified
-          ),
           // Keep ordering scoped to the tournament ruleset so pagination stays in sync
           // when a player switches between ruleset tabs.
           input.ruleset != null
@@ -720,10 +706,6 @@ export const getPlayerBeatmaps = publicProcedure
       .where(
         and(
           inArray(schema.beatmaps.id, beatmapIds),
-          eq(
-            schema.tournaments.verificationStatus,
-            VerificationStatus.Verified
-          ),
           // Ensure hydrated tournaments also belong to the requested ruleset.
           input.ruleset != null
             ? eq(schema.tournaments.ruleset, input.ruleset)

--- a/apps/web/app/server/oRPC/procedures/playerProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/playerProcedures.ts
@@ -561,9 +561,7 @@ export const getPlayerBeatmaps = publicProcedure
       FROM join_pooled_beatmaps jpb
       INNER JOIN tournaments t ON t.id = jpb.tournaments_pooled_in_id
       WHERE jpb.pooled_beatmaps_id = ${schema.beatmaps.id}
-        ${input.ruleset != null
-          ? sql`AND t.ruleset = ${input.ruleset}`
-          : sql``}
+        ${input.ruleset != null ? sql`AND t.ruleset = ${input.ruleset}` : sql``}
     )`;
     const gameCountExpr = sql<number>`(
       SELECT COUNT(g.id)
@@ -571,12 +569,10 @@ export const getPlayerBeatmaps = publicProcedure
       INNER JOIN matches m ON m.id = g.match_id
       INNER JOIN tournaments t ON t.id = m.tournament_id
       WHERE g.beatmap_id = ${schema.beatmaps.id}
-        AND g.verification_status = ${VerificationStatus.Verified}
-        AND m.verification_status = ${VerificationStatus.Verified}
         AND t.verification_status = ${VerificationStatus.Verified}
-        ${input.ruleset != null
-          ? sql`AND t.ruleset = ${input.ruleset}`
-          : sql``}
+        AND m.verification_status = ${VerificationStatus.Verified}
+        AND g.verification_status = ${VerificationStatus.Verified}
+        ${input.ruleset != null ? sql`AND t.ruleset = ${input.ruleset}` : sql``}
     )`;
 
     const beatmapOrderingRows = await context.db

--- a/apps/web/components/beatmap/BeatmapTournamentCard.tsx
+++ b/apps/web/components/beatmap/BeatmapTournamentCard.tsx
@@ -29,6 +29,7 @@ import {
 import { Button } from '../ui/button';
 import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { VerificationStatus } from '@otr/core/osu';
 import { format } from 'date-fns';
 import { formatUTCDate } from '@/lib/utils/date';
 import { orpc } from '@/lib/orpc/orpc';
@@ -165,8 +166,10 @@ export default function BeatmapTournamentCard({
           <div className="flex items-center gap-1.5">
             <Gamepad2 className="h-4 w-4 flex-shrink-0" />
             <span>
-              {tournament.gameCount}{' '}
-              {tournament.gameCount === 1 ? 'game' : 'games'}
+              {tournament.tournament.verificationStatus ===
+              VerificationStatus.Verified
+                ? `${tournament.gameCount} ${tournament.gameCount === 1 ? 'game' : 'games'}`
+                : 'N/A'}
             </span>
           </div>
 
@@ -183,6 +186,10 @@ export default function BeatmapTournamentCard({
         <Button
           data-testid={`beatmap-tournament-details-toggle-${tournament.tournament.id}`}
           variant="outline"
+          disabled={
+            tournament.tournament.verificationStatus !==
+            VerificationStatus.Verified
+          }
           className={cn(
             '-my-1 ml-auto h-8 gap-2 px-3 text-sm sm:ml-0',
             'hover:bg-accent hover:text-accent-foreground',

--- a/apps/web/components/beatmap/BeatmapTournamentsList.tsx
+++ b/apps/web/components/beatmap/BeatmapTournamentsList.tsx
@@ -82,7 +82,7 @@ function NoResultsCard() {
       </CardHeader>
       <CardContent className="flex flex-col items-center justify-center space-y-2 text-center">
         <p className="text-muted-foreground">
-          This beatmap has not been used in any verified tournaments.
+          This beatmap has not been pooled in any tournaments.
         </p>
       </CardContent>
     </Card>

--- a/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
+++ b/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
@@ -144,7 +144,7 @@ export default function PlayerBeatmapTournamentTable({
                         <div className="text-center">
                           {tournament.verificationStatus ===
                           VerificationStatus.Verified
-                            ? tournament.gamesPlayed ?? 0
+                            ? (tournament.gamesPlayed ?? 0)
                             : 'N/A'}
                         </div>
                       </TableCell>

--- a/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
+++ b/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
@@ -131,7 +131,7 @@ export default function PlayerBeatmapTournamentTable({
                           {tournament.verificationStatus ===
                           VerificationStatus.Verified ? (
                             tournament.mostCommonMod === Mods.None ? (
-                              <span>N/A</span>
+                              '—'
                             ) : (
                               <ModIconset
                                 mods={tournament.mostCommonMod ?? Mods.None}

--- a/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
+++ b/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
@@ -22,7 +22,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import SimpleTooltip from '../simple-tooltip';
-import { Mods } from '@otr/core/osu';
+import { Mods, VerificationStatus } from '@otr/core/osu';
 
 interface PlayerBeatmapTournamentTableProps {
   tournaments: BeatmapTournamentListItem[];
@@ -142,7 +142,10 @@ export default function PlayerBeatmapTournamentTable({
                       </TableCell>
                       <TableCell className="py-2 text-sm text-muted-foreground">
                         <div className="text-center">
-                          {tournament.gamesPlayed ?? 0}
+                          {tournament.verificationStatus ===
+                          VerificationStatus.Verified
+                            ? tournament.gamesPlayed ?? 0
+                            : 'N/A'}
                         </div>
                       </TableCell>
                     </TableRow>

--- a/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
+++ b/apps/web/components/player/PlayerBeatmapTournamentTable.tsx
@@ -128,15 +128,20 @@ export default function PlayerBeatmapTournamentTable({
                       </TableCell>
                       <TableCell className="py-2 text-muted-foreground">
                         <div className="flex h-7 items-center justify-center">
-                          {tournament.mostCommonMod === Mods.None ? (
-                            <span>N/A</span>
+                          {tournament.verificationStatus ===
+                          VerificationStatus.Verified ? (
+                            tournament.mostCommonMod === Mods.None ? (
+                              <span>N/A</span>
+                            ) : (
+                              <ModIconset
+                                mods={tournament.mostCommonMod ?? Mods.None}
+                                className="flex h-full items-center"
+                                iconClassName="h-7"
+                                alwaysExpanded={true}
+                              />
+                            )
                           ) : (
-                            <ModIconset
-                              mods={tournament.mostCommonMod ?? Mods.None}
-                              className="flex h-full items-center"
-                              iconClassName="h-7"
-                              alwaysExpanded={true}
-                            />
+                            '—'
                           )}
                         </div>
                       </TableCell>
@@ -145,7 +150,7 @@ export default function PlayerBeatmapTournamentTable({
                           {tournament.verificationStatus ===
                           VerificationStatus.Verified
                             ? (tournament.gamesPlayed ?? 0)
-                            : 'N/A'}
+                            : '—'}
                         </div>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
Resolves #719 

<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/e5623a0b-3be0-4b1b-9693-87c4eb9061ad" />
<img width="1188" height="683" alt="image" src="https://github.com/user-attachments/assets/9c8cf257-7fe1-4767-ba11-9fe090393cdb" />

Also fixes an issue where beatmaps were not being sorted properly when pooled in multiple different gamemodes (count used for sorting was including all gamemodes).
