### PR TITLE
Hide "Details" button from non-verified tournaments in beatmap page

### DIFF
--- a/apps/web/components/beatmap/BeatmapTournamentCard.tsx
+++ b/apps/web/components/beatmap/BeatmapTournamentCard.tsx
@@ -183,31 +183,30 @@ export default function BeatmapTournamentCard({
           )}
         </div>
 
-        <Button
-          data-testid={`beatmap-tournament-details-toggle-${tournament.tournament.id}`}
-          variant="outline"
-          disabled={
-            tournament.tournament.verificationStatus !==
-            VerificationStatus.Verified
-          }
-          className={cn(
-            '-my-1 ml-auto h-8 gap-2 px-3 text-sm sm:ml-0',
-            'hover:bg-accent hover:text-accent-foreground',
-            'border border-input',
-            isDetailsVisible && 'bg-accent text-accent-foreground'
-          )}
-          onClick={(e) => {
-            e.preventDefault();
-            setIsDetailsVisible(!isDetailsVisible);
-          }}
-        >
-          {isDetailsVisible ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-          Details
-        </Button>
+        {tournament.tournament.verificationStatus ===
+          VerificationStatus.Verified && (
+          <Button
+            data-testid={`beatmap-tournament-details-toggle-${tournament.tournament.id}`}
+            variant="outline"
+            className={cn(
+              '-my-1 ml-auto h-8 gap-2 px-3 text-sm sm:ml-0',
+              'hover:bg-accent hover:text-accent-foreground',
+              'border border-input',
+              isDetailsVisible && 'bg-accent text-accent-foreground'
+            )}
+            onClick={(e) => {
+              e.preventDefault();
+              setIsDetailsVisible(!isDetailsVisible);
+            }}
+          >
+            {isDetailsVisible ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            Details
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/e2e/beatmaps.e2e.ts
+++ b/apps/web/e2e/beatmaps.e2e.ts
@@ -277,6 +277,9 @@ test.describe('Beatmap Detail Page', () => {
       await page.goto(ROUTES.beatmap(TEST_BEATMAP_OSU_ID));
       await page.waitForLoadState('networkidle');
 
+      // The details toggle is only rendered for verified tournaments, so this
+      // selector targets verified tournaments only. Non-verified (e.g. rejected)
+      // tournaments have no toggle and no expandable details.
       const toggle = page.locator(
         '[data-testid^="beatmap-tournament-details-toggle-"]'
       );


### PR DESCRIPTION
Resolves an issue where the tournaments page was displaying a "Details" button for non-verified tournaments (it was just disabled). This was caught in e2e testing and the failing case is now corrected.