### PR TITLE
Fix recharts warnings

### DIFF
--- a/apps/web/components/player/PlayerRatingChartView.tsx
+++ b/apps/web/components/player/PlayerRatingChartView.tsx
@@ -10,7 +10,6 @@ import {
   ReferenceLine,
   DotProps,
   Legend,
-  ResponsiveContainer,
 } from 'recharts';
 import PlayerRatingChartTooltip from './PlayerRatingChartTooltip';
 import { capitalize } from '@/lib/utils';
@@ -263,76 +262,72 @@ export default function PlayerRatingChartView({
       config={chartConfig}
       className="max-h-[375px] min-h-[300px] w-full"
     >
-      <ResponsiveContainer>
-        <LineChart data={chartData}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            stroke={chartColors.grid}
-            vertical={false}
-          />
-          <XAxis
-            type="number"
-            dataKey="timestampValue"
-            domain={['dataMin', 'dataMax']}
-            scale="time"
-            stroke={chartColors.text}
-            tick={{ fill: chartColors.text, fontSize: 12 }}
-            tickLine={{ stroke: chartColors.grid }}
-            fontFamily="sans-serif"
-            ticks={xAxisTickMarks}
-            tickFormatter={formatXAxisTick}
-            interval="preserveStartEnd"
-          />
-          <YAxis
-            stroke={chartColors.text}
-            tick={{ fill: chartColors.text, fontSize: 12 }}
-            tickLine={{ stroke: chartColors.grid }}
-            tickFormatter={formatYAxisTick}
-            domain={yAxisConfig.domain}
-            ticks={yAxisConfig.ticks}
-            width={CHART_CONSTANTS.Y_AXIS_WIDTH}
-          />
-          <RechartsTooltip
-            content={<PlayerRatingChartTooltip activeTab={activeTab} />}
-            cursor={{
-              stroke: chartColors.text,
-              strokeWidth: 1,
-              strokeDasharray: '3 3',
+      <LineChart data={chartData}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke={chartColors.grid}
+          vertical={false}
+        />
+        <XAxis
+          type="number"
+          dataKey="timestampValue"
+          domain={['dataMin', 'dataMax']}
+          scale="time"
+          stroke={chartColors.text}
+          tick={{ fill: chartColors.text, fontSize: 12 }}
+          tickLine={{ stroke: chartColors.grid }}
+          fontFamily="sans-serif"
+          ticks={xAxisTickMarks}
+          tickFormatter={formatXAxisTick}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          stroke={chartColors.text}
+          tick={{ fill: chartColors.text, fontSize: 12 }}
+          tickLine={{ stroke: chartColors.grid }}
+          tickFormatter={formatYAxisTick}
+          domain={yAxisConfig.domain}
+          ticks={yAxisConfig.ticks}
+          width={CHART_CONSTANTS.Y_AXIS_WIDTH}
+        />
+        <RechartsTooltip
+          content={<PlayerRatingChartTooltip activeTab={activeTab} />}
+          cursor={{
+            stroke: chartColors.text,
+            strokeWidth: 1,
+            strokeDasharray: '3 3',
+          }}
+        />
+        <Legend />
+        {activeTab === 'rating' && highestRating && (
+          <ReferenceLine
+            y={highestRating}
+            label={{
+              value: 'Peak',
+              position: 'insideTopLeft',
+              fill: chartColors.text,
+              fontSize: 12,
             }}
+            stroke={chartColors.rating}
+            strokeDasharray="4 4"
+            strokeWidth={1.5}
           />
-          <Legend />
-          {activeTab === 'rating' && highestRating && (
-            <ReferenceLine
-              y={highestRating}
-              label={{
-                value: 'Peak',
-                position: 'insideTopLeft',
-                fill: chartColors.text,
-                fontSize: 12,
-              }}
-              stroke={chartColors.rating}
-              strokeDasharray="4 4"
-              strokeWidth={1.5}
-            />
-          )}
-          <Line
-            type="monotone"
-            dataKey={`${activeTab}After`}
-            name={capitalize(activeTab)}
-            stroke={
-              activeTab === 'rating'
-                ? chartColors.rating
-                : chartColors.volatility
-            }
-            strokeWidth={CHART_CONSTANTS.LINE_WIDTH}
-            dot={false}
-            activeDot={(props: unknown) =>
-              renderActiveDot(props as DotProps) || <></>
-            }
-            connectNulls
-          />
-        </LineChart>
-      </ResponsiveContainer>
+        )}
+        <Line
+          type="monotone"
+          dataKey={`${activeTab}After`}
+          name={capitalize(activeTab)}
+          stroke={
+            activeTab === 'rating' ? chartColors.rating : chartColors.volatility
+          }
+          strokeWidth={CHART_CONSTANTS.LINE_WIDTH}
+          dot={false}
+          activeDot={(props: unknown) =>
+            renderActiveDot(props as DotProps) || <></>
+          }
+          connectNulls
+        />
+      </LineChart>
     </ChartContainer>
   );
 }

--- a/apps/web/components/stats/TournamentVerificationChart.tsx
+++ b/apps/web/components/stats/TournamentVerificationChart.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import {
-  BarChart,
-  XAxis,
-  YAxis,
-  Bar,
-  ResponsiveContainer,
-  Cell,
-} from 'recharts';
+import { BarChart, XAxis, YAxis, Bar, Cell } from 'recharts';
 import {
   ChartConfig,
   ChartContainer,
@@ -156,60 +149,58 @@ export default function TournamentVerificationChart({
           config={chartConfig}
           className="mx-auto max-h-[300px] w-full"
         >
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              accessibilityLayer
-              data={chartData}
-              margin={CHART_CONSTANTS.VERTICAL_MARGIN}
-              layout="vertical"
-            >
-              <YAxis
-                dataKey="status"
-                type="category"
-                tickLine={false}
-                tickMargin={10}
-                axisLine={false}
-                tick={{ fontSize: 14, fill: 'var(--foreground)' }}
-                interval={0}
-              />
-              <XAxis type="number" hide />
-              <ChartTooltip
-                cursor={false}
-                content={
-                  <ChartTooltipContent
-                    className="font-sans"
-                    labelFormatter={(value) => value}
-                    formatter={(value, name, entry) => (
-                      <div className="flex items-center justify-between gap-4">
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="h-3 w-3 rounded-full"
-                            style={{ backgroundColor: entry.payload.fill }}
-                          />
-                          <span className="font-medium">
-                            {formatChartNumber(value as number)}
-                          </span>
-                        </div>
-                        <span className="text-muted-foreground">
-                          (
-                          {formatPercentage(
-                            (entry.payload as ChartDataEntry).percentage,
-                            1
-                          )}
-                          )
+          <BarChart
+            accessibilityLayer
+            data={chartData}
+            margin={CHART_CONSTANTS.VERTICAL_MARGIN}
+            layout="vertical"
+          >
+            <YAxis
+              dataKey="status"
+              type="category"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tick={{ fontSize: 14, fill: 'var(--foreground)' }}
+              interval={0}
+            />
+            <XAxis type="number" hide />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  className="font-sans"
+                  labelFormatter={(value) => value}
+                  formatter={(value, name, entry) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="h-3 w-3 rounded-full"
+                          style={{ backgroundColor: entry.payload.fill }}
+                        />
+                        <span className="font-medium">
+                          {formatChartNumber(value as number)}
                         </span>
                       </div>
-                    )}
-                  />
-                }
-              />
-              <Bar dataKey="count" radius={5} maxBarSize={60}>
-                {chartData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.fill} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+                      <span className="text-muted-foreground">
+                        (
+                        {formatPercentage(
+                          (entry.payload as ChartDataEntry).percentage,
+                          1
+                        )}
+                        )
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+            <Bar dataKey="count" radius={5} maxBarSize={60}>
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
         </ChartContainer>
       </CardContent>
     </Card>

--- a/apps/web/components/ui/chart.tsx
+++ b/apps/web/components/ui/chart.tsx
@@ -24,6 +24,16 @@ type ChartContextProps = {
 
 const ChartContext = React.createContext<ChartContextProps | null>(null);
 
+/**
+ * recharts v3's `ResponsiveContainer` defaults `initialDimension` to
+ * `{ width: -1, height: -1 }` and logs a console warning ("The width(-1) and
+ * height(-1) of chart should be greater than 0...") whenever it renders before
+ * it can measure its parent.
+ *
+ * Seeding an initial size suppresses the warning without altering the UI
+ */
+const CHART_INITIAL_DIMENSION = { width: 800, height: 450 } as const;
+
 function useChart() {
   const context = React.useContext(ChartContext);
 
@@ -61,7 +71,9 @@ function ChartContainer({
         {...props}
       >
         <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>
+        <RechartsPrimitive.ResponsiveContainer
+          initialDimension={CHART_INITIAL_DIMENSION}
+        >
           {children}
         </RechartsPrimitive.ResponsiveContainer>
       </div>


### PR DESCRIPTION
- Fixes erroneous warnings displaying in e2e tests by seeding an initial chart size. This started happening after our recent upgrade to latest package versions.
- Removes ResponsiveContainer wrapper from a few charts.