### PR TITLE
Allow users to view and track the status of their data reports

### DIFF
--- a/apps/web/app/reports/MyReportsClient.tsx
+++ b/apps/web/app/reports/MyReportsClient.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Label } from '@/components/ui/label';
+import {
+  ReportEntityTypeEnumHelper,
+  ReportStatusEnumHelper,
+} from '@/lib/enum-helpers';
+import { orpc } from '@/lib/orpc/orpc';
+import type { MyReport } from '@/lib/orpc/schema/report';
+import { ReportEntityType, ReportStatus } from '@otr/core/osu';
+import { cn } from '@/lib/utils';
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) return '—';
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return '—';
+  return timestamp.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
+const formatFieldName = (field: string) =>
+  field
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (str) => str.toUpperCase())
+    .trim();
+
+function getEntityLink(
+  entityType: ReportEntityType,
+  entityId: number,
+  matchId?: number
+): string {
+  switch (entityType) {
+    case ReportEntityType.Tournament:
+      return `/tournaments/${entityId}`;
+    case ReportEntityType.Match:
+      return `/matches/${entityId}`;
+    case ReportEntityType.Game:
+      return matchId ? `/matches/${matchId}?gameId=${entityId}` : '#';
+    case ReportEntityType.Score:
+      return matchId ? `/matches/${matchId}?scoreId=${entityId}` : '#';
+    default:
+      return '#';
+  }
+}
+
+function getStatusBadge(status: ReportStatus) {
+  const metadata = ReportStatusEnumHelper.getMetadata(status);
+  return (
+    <Badge
+      variant={
+        status === ReportStatus.Pending
+          ? 'secondary'
+          : status === ReportStatus.Approved
+            ? 'default'
+            : 'destructive'
+      }
+      className={cn(
+        status === ReportStatus.Approved && 'bg-green-600 hover:bg-green-600/80'
+      )}
+    >
+      {metadata.text}
+    </Badge>
+  );
+}
+
+export default function MyReportsClient() {
+  const [reports, setReports] = useState<MyReport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedReport, setSelectedReport] = useState<MyReport | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    orpc.reports
+      .listMine({})
+      .then((data) => {
+        if (active) setReports(data.reports);
+      })
+      .catch((error) => {
+        console.error('[my-reports] failed to fetch reports', error);
+        toast.error('Failed to load your reports');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleViewDetails = useCallback((report: MyReport) => {
+    setSelectedReport(report);
+    setDetailsOpen(true);
+
+    if (!report.hasUnreadUpdate) return;
+
+    // Opening a report acknowledges the admin's update, clearing its indicator.
+    setReports((prev) =>
+      prev.map((r) =>
+        r.id === report.id ? { ...r, hasUnreadUpdate: false } : r
+      )
+    );
+    orpc.reports.markMineViewed({ reportId: report.id }).catch((error) => {
+      console.error('[my-reports] failed to mark report viewed', error);
+    });
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <Card data-testid="my-reports-card">
+        <CardHeader>
+          <CardTitle>Reports</CardTitle>
+          <CardDescription>
+            Data issues you&apos;ve reported and their current status
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex items-center gap-3 py-8 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading your reports...
+            </div>
+          ) : reports.length === 0 ? (
+            <p
+              className="py-8 text-center text-sm text-muted-foreground"
+              data-testid="my-reports-empty"
+            >
+              You haven&apos;t submitted any reports.
+            </p>
+          ) : (
+            <div
+              className="overflow-hidden rounded-md border"
+              data-testid="my-reports-list"
+            >
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-8" />
+                    <TableHead>Type</TableHead>
+                    <TableHead>Entity</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Submitted</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {reports.map((report) => (
+                    <TableRow
+                      key={report.id}
+                      data-testid="my-reports-row"
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`View report for ${report.entityDisplayName}`}
+                      className="cursor-pointer"
+                      onClick={() => handleViewDetails(report)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          handleViewDetails(report);
+                        }
+                      }}
+                    >
+                      <TableCell className="py-3">
+                        {report.hasUnreadUpdate && (
+                          <span
+                            className="block size-2.5 rounded-full bg-blue-500"
+                            data-testid="my-reports-unread-dot"
+                            aria-label="Unread admin update"
+                            title="Unread admin update"
+                          />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {
+                          ReportEntityTypeEnumHelper.getMetadata(
+                            report.entityType
+                          ).text
+                        }
+                      </TableCell>
+                      <TableCell className="max-w-[20rem] truncate">
+                        {report.entityDisplayName}
+                      </TableCell>
+                      <TableCell>{getStatusBadge(report.status)}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatDateTime(report.created)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
+        <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Report Details</DialogTitle>
+            <DialogDescription>
+              {selectedReport &&
+                ReportEntityTypeEnumHelper.getMetadata(
+                  selectedReport.entityType
+                ).text}{' '}
+              • {selectedReport?.entityDisplayName}
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedReport && (
+            <div className="space-y-6">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Status
+                  </Label>
+                  <div className="mt-1">
+                    {getStatusBadge(selectedReport.status)}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Entity
+                  </Label>
+                  <p className="mt-1 text-sm">
+                    <Link
+                      href={getEntityLink(
+                        selectedReport.entityType,
+                        selectedReport.entityId,
+                        selectedReport.matchId
+                      )}
+                      className="text-primary hover:underline"
+                    >
+                      {selectedReport.entityDisplayName}
+                    </Link>
+                  </p>
+                </div>
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Submitted
+                  </Label>
+                  <p className="text-sm">
+                    {formatDateTime(selectedReport.created)}
+                  </p>
+                </div>
+                {selectedReport.resolvedAt && (
+                  <div>
+                    <Label className="text-xs text-muted-foreground">
+                      Reviewed
+                    </Label>
+                    <p className="text-sm">
+                      {formatDateTime(selectedReport.resolvedAt)}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {Object.keys(
+                selectedReport.suggestedChanges as Record<string, string>
+              ).length > 0 && (
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Reported Fields
+                  </Label>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {Object.keys(
+                      selectedReport.suggestedChanges as Record<string, string>
+                    ).map((field) => (
+                      <Badge key={field} variant="secondary">
+                        {formatFieldName(field)}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {Object.values(
+                selectedReport.suggestedChanges as Record<string, string>
+              ).some((v) => v) && (
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Suggested Changes
+                  </Label>
+                  <p className="mt-2 rounded-md bg-muted/50 p-3 text-sm [overflow-wrap:anywhere] whitespace-pre-wrap">
+                    {Object.values(
+                      selectedReport.suggestedChanges as Record<string, string>
+                    )[0] ?? '—'}
+                  </p>
+                </div>
+              )}
+
+              <div>
+                <Label className="text-xs text-muted-foreground">
+                  Your Justification
+                </Label>
+                <p className="mt-2 rounded-md bg-muted/50 p-3 text-sm [overflow-wrap:anywhere]">
+                  {selectedReport.justification}
+                </p>
+              </div>
+
+              {selectedReport.adminNote && (
+                <div>
+                  <Label className="text-xs text-muted-foreground">
+                    Admin Response
+                  </Label>
+                  <p className="mt-2 rounded-md bg-muted/50 p-3 text-sm [overflow-wrap:anywhere] whitespace-pre-wrap">
+                    {selectedReport.adminNote}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/app/reports/MyReportsClient.tsx
+++ b/apps/web/app/reports/MyReportsClient.tsx
@@ -223,7 +223,10 @@ export default function MyReportsClient() {
       </Card>
 
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
-        <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+        <DialogContent
+          className="max-h-[85vh] max-w-2xl overflow-y-auto"
+          data-testid="my-report-detail"
+        >
           <DialogHeader>
             <DialogTitle>Report Details</DialogTitle>
             <DialogDescription>

--- a/apps/web/app/reports/page.tsx
+++ b/apps/web/app/reports/page.tsx
@@ -1,0 +1,44 @@
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { AlertTriangle } from 'lucide-react';
+
+import MyReportsClient from './MyReportsClient';
+import { auth } from '@/lib/auth/auth';
+import { hasAdminScope } from '@/lib/auth/roles';
+
+export default async function ReportsPage() {
+  const headersList = await headers();
+  const session = await auth.api.getSession({ headers: headersList });
+
+  if (!session) {
+    redirect('/unauthorized');
+  }
+
+  // Admins manage every report from the dedicated admin view.
+  if (hasAdminScope(session.dbUser?.scopes ?? [])) {
+    redirect('/admin/reports');
+  }
+
+  return (
+    <div className="flex flex-col gap-10" data-testid="my-reports">
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <AlertTriangle className="size-8 text-primary" />
+          <div>
+            <h1
+              className="text-3xl font-semibold"
+              data-testid="my-reports-heading"
+            >
+              Your Reports
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Track the status of data issues you&apos;ve reported
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <MyReportsClient />
+    </div>
+  );
+}

--- a/apps/web/app/server/oRPC/procedures/reports/__tests__/reportReadStatus.test.ts
+++ b/apps/web/app/server/oRPC/procedures/reports/__tests__/reportReadStatus.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+
+import { hasUnreadAdminUpdate } from '../reportReadStatus';
+
+describe('hasUnreadAdminUpdate', () => {
+  it('returns false for a report that has not been resolved', () => {
+    expect(
+      hasUnreadAdminUpdate({ resolvedAt: null, reporterViewedAt: null })
+    ).toBe(false);
+  });
+
+  it('returns false for an unresolved report even if previously viewed', () => {
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: null,
+        reporterViewedAt: '2026-06-20T12:00:00Z',
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when resolved and never viewed', () => {
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: '2026-06-20T12:00:00Z',
+        reporterViewedAt: null,
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when the resolution is newer than the last view', () => {
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: '2026-06-20T12:00:00Z',
+        reporterViewedAt: '2026-06-20T11:59:59Z',
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when the report was viewed at or after the resolution', () => {
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: '2026-06-20T12:00:00Z',
+        reporterViewedAt: '2026-06-20T12:00:00Z',
+      })
+    ).toBe(false);
+
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: '2026-06-20T12:00:00Z',
+        reporterViewedAt: '2026-06-20T12:00:01Z',
+      })
+    ).toBe(false);
+  });
+
+  it('accepts Date instances as well as ISO strings', () => {
+    expect(
+      hasUnreadAdminUpdate({
+        resolvedAt: new Date('2026-06-20T12:00:00Z'),
+        reporterViewedAt: new Date('2026-06-20T11:00:00Z'),
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/app/server/oRPC/procedures/reports/reportProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/reports/reportProcedures.ts
@@ -1,10 +1,13 @@
 import { ORPCError } from '@orpc/server';
-import { and, desc, eq, gt, sql } from 'drizzle-orm';
+import { and, desc, eq, gt, isNotNull, isNull, or, sql } from 'drizzle-orm';
 
 import * as schema from '@otr/core/db/schema';
 import { ReportEntityType, ReportStatus } from '@otr/core/osu/enums';
 
 import {
+  MarkReportViewedInputSchema,
+  MyReportListResponseSchema,
+  MyUnreadReportCountResponseSchema,
   ReportCreateInputSchema,
   ReportGetInputSchema,
   ReportListInputSchema,
@@ -18,6 +21,7 @@ import {
 
 import { protectedProcedure } from '../base';
 import { ensureAdminSession } from '../shared/adminGuard';
+import { hasUnreadAdminUpdate } from './reportReadStatus';
 
 const NOW = sql`CURRENT_TIMESTAMP`;
 
@@ -514,4 +518,124 @@ export const markReportsViewed = protectedProcedure
       .where(eq(schema.users.id, adminUserId));
 
     return { success: true };
+  });
+
+const unreadUpdateCondition = (userId: number) =>
+  and(
+    eq(schema.dataReports.reporterUserId, userId),
+    isNotNull(schema.dataReports.resolvedAt),
+    or(
+      isNull(schema.dataReports.reporterViewedAt),
+      gt(schema.dataReports.resolvedAt, schema.dataReports.reporterViewedAt)
+    )
+  );
+
+export const listMyReports = protectedProcedure
+  .output(MyReportListResponseSchema)
+  .route({
+    summary: "List the current user's own reports",
+    tags: ['reports'],
+    method: 'GET',
+    path: '/reports/mine',
+  })
+  .handler(async ({ context }) => {
+    const userId = context.session?.dbUser?.id;
+    if (!userId) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'User not authenticated',
+      });
+    }
+
+    const reports = await context.db.query.dataReports.findMany({
+      where: eq(schema.dataReports.reporterUserId, userId),
+      orderBy: desc(schema.dataReports.created),
+    });
+
+    const mappedReports = await Promise.all(
+      reports.map(async (report) => ({
+        id: report.id,
+        entityType: report.entityType,
+        entityId: report.entityId,
+        suggestedChanges: report.suggestedChanges as Record<string, string>,
+        justification: report.justification,
+        status: report.status,
+        adminNote: report.adminNote,
+        created: report.created,
+        resolvedAt: report.resolvedAt,
+        entityDisplayName: await getEntityDisplayName(
+          context.db,
+          report.entityType,
+          report.entityId
+        ),
+        matchId: await getMatchIdForEntity(
+          context.db,
+          report.entityType,
+          report.entityId
+        ),
+        hasUnreadUpdate: hasUnreadAdminUpdate(report),
+      }))
+    );
+
+    return { reports: mappedReports };
+  });
+
+export const markMyReportViewed = protectedProcedure
+  .input(MarkReportViewedInputSchema)
+  .output(ReportMutationResponseSchema)
+  .route({
+    summary: "Mark one of the current user's reports as viewed",
+    tags: ['reports'],
+    method: 'POST',
+    path: '/reports/{reportId}/mark-viewed',
+  })
+  .handler(async ({ input, context }) => {
+    const userId = context.session?.dbUser?.id;
+    if (!userId) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'User not authenticated',
+      });
+    }
+
+    const updated = await context.db
+      .update(schema.dataReports)
+      .set({ reporterViewedAt: NOW })
+      .where(
+        and(
+          eq(schema.dataReports.id, input.reportId),
+          eq(schema.dataReports.reporterUserId, userId)
+        )
+      )
+      .returning({ id: schema.dataReports.id });
+
+    if (updated.length === 0) {
+      throw new ORPCError('NOT_FOUND', {
+        message: 'Report not found',
+      });
+    }
+
+    return { success: true, reportId: input.reportId };
+  });
+
+export const getMyUnreadReportCount = protectedProcedure
+  .output(MyUnreadReportCountResponseSchema)
+  .route({
+    summary: "Count the current user's reports with unread admin updates",
+    tags: ['reports'],
+    method: 'GET',
+    path: '/reports/mine/unread-count',
+  })
+  .handler(async ({ context }) => {
+    const userId = context.session?.dbUser?.id;
+    if (!userId) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'User not authenticated',
+      });
+    }
+
+    const [result] = await context.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(schema.dataReports)
+      .where(unreadUpdateCondition(userId));
+
+    return { count: result?.count ?? 0 };
   });

--- a/apps/web/app/server/oRPC/procedures/reports/reportProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/reports/reportProcedures.ts
@@ -536,7 +536,7 @@ export const listMyReports = protectedProcedure
     summary: "List the current user's own reports",
     tags: ['reports'],
     method: 'GET',
-    path: '/reports/mine',
+    path: '/reports/me',
   })
   .handler(async ({ context }) => {
     const userId = context.session?.dbUser?.id;
@@ -622,7 +622,7 @@ export const getMyUnreadReportCount = protectedProcedure
     summary: "Count the current user's reports with unread admin updates",
     tags: ['reports'],
     method: 'GET',
-    path: '/reports/mine/unread-count',
+    path: '/reports/me/unread-count',
   })
   .handler(async ({ context }) => {
     const userId = context.session?.dbUser?.id;

--- a/apps/web/app/server/oRPC/procedures/reports/reportReadStatus.ts
+++ b/apps/web/app/server/oRPC/procedures/reports/reportReadStatus.ts
@@ -1,0 +1,25 @@
+type ReportReadState = {
+  resolvedAt: string | Date | null;
+  reporterViewedAt: string | Date | null;
+};
+
+const toTime = (value: string | Date): number =>
+  value instanceof Date ? value.getTime() : new Date(value).getTime();
+
+/**
+ * Determines whether a report carries an admin update the reporter has not yet seen.
+ *
+ * An "update" is an admin resolution (`resolvedAt` set). It is unread until the
+ * reporter opens the report (`reporterViewedAt`) at or after that resolution.
+ */
+export const hasUnreadAdminUpdate = (report: ReportReadState): boolean => {
+  if (!report.resolvedAt) {
+    return false;
+  }
+
+  if (!report.reporterViewedAt) {
+    return true;
+  }
+
+  return toTime(report.resolvedAt) > toTime(report.reporterViewedAt);
+};

--- a/apps/web/app/server/oRPC/router.ts
+++ b/apps/web/app/server/oRPC/router.ts
@@ -89,9 +89,12 @@ import {
 import { massEnqueue } from './procedures/admin/massEnqueueProcedures';
 import {
   createReport,
+  getMyUnreadReportCount,
   getReport,
   getUnseenReportCount,
+  listMyReports,
   listReports,
+  markMyReportViewed,
   markReportsViewed,
   reopenReport,
   resolveReport,
@@ -120,6 +123,9 @@ export const router = base.router({
     reopen: reopenReport,
     unseenCount: getUnseenReportCount,
     markViewed: markReportsViewed,
+    listMine: listMyReports,
+    markMineViewed: markMyReportViewed,
+    myUnreadCount: getMyUnreadReportCount,
   },
   user: {
     get: getUser,

--- a/apps/web/components/profile/ProfileCard.tsx
+++ b/apps/web/components/profile/ProfileCard.tsx
@@ -65,15 +65,28 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
   const isAdmin = hasAdminScope(scopes);
   const isLoading = Boolean(isSessionPending);
   const { refreshSession } = useContext(SessionContext);
+  const userId = session?.dbUser?.id ?? null;
+  // Admins track the pending review queue; everyone else tracks unread updates
+  // to the reports they submitted.
   const [unseenReportCount, setUnseenReportCount] = useState(0);
+  const [myUnreadReportCount, setMyUnreadReportCount] = useState(0);
 
   useEffect(() => {
-    if (!isAdmin) return;
+    if (!userId) return;
 
-    orpc.reports.unseenCount({}).then((result) => {
-      setUnseenReportCount(result.count);
-    });
-  }, [isAdmin]);
+    if (isAdmin) {
+      orpc.reports
+        .unseenCount({})
+        .then((result) => setUnseenReportCount(result.count))
+        .catch(() => setUnseenReportCount(0));
+      return;
+    }
+
+    orpc.reports
+      .myUnreadCount({})
+      .then((result) => setMyUnreadReportCount(result.count))
+      .catch(() => setMyUnreadReportCount(0));
+  }, [isAdmin, userId]);
 
   const handleLogout = async () => {
     await signOut({
@@ -101,8 +114,26 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
 
   const player = dbPlayer;
 
+  const reportsHref = isAdmin ? '/admin/reports' : '/reports';
   const reportCountDisplay =
     unseenReportCount > 99 ? '99+' : unseenReportCount.toString();
+  // Admins see a queue count; reporters see a single "you have updates" dot.
+  const hasReportNotification = isAdmin
+    ? unseenReportCount > 0
+    : myUnreadReportCount > 0;
+
+  const reportsIndicator = isAdmin
+    ? unseenReportCount > 0 && (
+        <span className="rounded-full bg-blue-500 px-1.5 py-0.5 text-xs font-medium text-white">
+          {reportCountDisplay}
+        </span>
+      )
+    : myUnreadReportCount > 0 && (
+        <span
+          className="size-2 rounded-full bg-blue-500"
+          aria-label="Unread report updates"
+        />
+      );
 
   if (isMobile) {
     return (
@@ -123,7 +154,7 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
               <div className="flex items-center gap-3">
                 <UserAvatar
                   player={player}
-                  showNotificationDot={unseenReportCount > 0}
+                  showNotificationDot={hasReportNotification}
                 />
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium">{player.username}</span>
@@ -188,39 +219,11 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
             </Link>
           )}
 
-          {isAdmin && (
+          <hr className="my-1 border-border" />
+          {isMobileNav ? (
             <>
-              <hr className="my-1 border-border" />
-              {isMobileNav ? (
-                <>
-                  <SheetClose asChild>
-                    <Link
-                      href="/admin"
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-                    >
-                      <ShieldAlert className="size-4" />
-                      <span>Admin</span>
-                    </Link>
-                  </SheetClose>
-                  <SheetClose asChild>
-                    <Link
-                      href="/admin/reports"
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-                    >
-                      <AlertTriangle className="size-4" />
-                      <span className="flex items-center gap-2">
-                        Reports
-                        {unseenReportCount > 0 && (
-                          <span className="rounded-full bg-blue-500 px-1.5 py-0.5 text-xs font-medium text-white">
-                            {reportCountDisplay}
-                          </span>
-                        )}
-                      </span>
-                    </Link>
-                  </SheetClose>
-                </>
-              ) : (
-                <>
+              {isAdmin && (
+                <SheetClose asChild>
                   <Link
                     href="/admin"
                     className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
@@ -228,22 +231,42 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
                     <ShieldAlert className="size-4" />
                     <span>Admin</span>
                   </Link>
-                  <Link
-                    href="/admin/reports"
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-                  >
-                    <AlertTriangle className="size-4" />
-                    <span className="flex items-center gap-2">
-                      Reports
-                      {unseenReportCount > 0 && (
-                        <span className="rounded-full bg-blue-500 px-1.5 py-0.5 text-xs font-medium text-white">
-                          {reportCountDisplay}
-                        </span>
-                      )}
-                    </span>
-                  </Link>
-                </>
+                </SheetClose>
               )}
+              <SheetClose asChild>
+                <Link
+                  href={reportsHref}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+                >
+                  <AlertTriangle className="size-4" />
+                  <span className="flex items-center gap-2">
+                    Reports
+                    {reportsIndicator}
+                  </span>
+                </Link>
+              </SheetClose>
+            </>
+          ) : (
+            <>
+              {isAdmin && (
+                <Link
+                  href="/admin"
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+                >
+                  <ShieldAlert className="size-4" />
+                  <span>Admin</span>
+                </Link>
+              )}
+              <Link
+                href={reportsHref}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+              >
+                <AlertTriangle className="size-4" />
+                <span className="flex items-center gap-2">
+                  Reports
+                  {reportsIndicator}
+                </span>
+              </Link>
             </>
           )}
 
@@ -270,7 +293,7 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
         >
           <UserAvatar
             player={player}
-            showNotificationDot={unseenReportCount > 0}
+            showNotificationDot={hasReportNotification}
           />
         </motion.div>
       </DropdownMenuTrigger>
@@ -318,30 +341,24 @@ export default function ProfileCard({ isMobileNav = false }: ProfileCardProps) {
             <span>Settings</span>
           </Link>
         </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {isAdmin && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild className="cursor-pointer">
-              <Link href="/admin">
-                <ShieldAlert className="mr-2 size-4" />
-                <span>Admin</span>
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild className="cursor-pointer">
-              <Link href="/admin/reports">
-                <AlertTriangle className="mr-2 size-4" />
-                <span className="flex items-center gap-2">
-                  Reports
-                  {unseenReportCount > 0 && (
-                    <span className="rounded-full bg-blue-500 px-1.5 py-0.5 text-xs font-medium text-white">
-                      {reportCountDisplay}
-                    </span>
-                  )}
-                </span>
-              </Link>
-            </DropdownMenuItem>
-          </>
+          <DropdownMenuItem asChild className="cursor-pointer">
+            <Link href="/admin">
+              <ShieldAlert className="mr-2 size-4" />
+              <span>Admin</span>
+            </Link>
+          </DropdownMenuItem>
         )}
+        <DropdownMenuItem asChild className="cursor-pointer">
+          <Link href={reportsHref}>
+            <AlertTriangle className="mr-2 size-4" />
+            <span className="flex items-center gap-2">
+              Reports
+              {reportsIndicator}
+            </span>
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="cursor-pointer text-destructive hover:bg-destructive/10 focus:text-destructive"

--- a/apps/web/drizzle/0018_soft_miek.sql
+++ b/apps/web/drizzle/0018_soft_miek.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "data_reports" ADD COLUMN "reporter_viewed_at" timestamp with time zone;

--- a/apps/web/drizzle/meta/0018_snapshot.json
+++ b/apps/web/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,6183 @@
+{
+  "id": "334f29ae-4b5d-4399-8b8b-840c93f487ba",
+  "prevId": "137cae10-6c23-451c-881a-c525619f6505",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_api_keys_reference_id": {
+          "name": "ix_api_keys_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_auth_users_id_fk": {
+          "name": "api_keys_user_id_auth_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_reference_id_auth_users_id_fk": {
+          "name": "api_keys_reference_id_auth_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "auth_users",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_users_player_id_key": {
+          "name": "auth_users_player_id_key",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_users_player_id_players_id_fk": {
+          "name": "auth_users_player_id_players_id_fk",
+          "tableFrom": "auth_users",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beatmap_attributes": {
+      "name": "beatmap_attributes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "beatmap_attributes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mods": {
+          "name": "mods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sr": {
+          "name": "sr",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beatmap_id": {
+          "name": "beatmap_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_beatmap_attributes_beatmap_id_mods": {
+          "name": "ix_beatmap_attributes_beatmap_id_mods",
+          "columns": [
+            {
+              "expression": "beatmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "mods",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_beatmap_attributes_beatmaps_beatmap_id": {
+          "name": "fk_beatmap_attributes_beatmaps_beatmap_id",
+          "tableFrom": "beatmap_attributes",
+          "tableTo": "beatmaps",
+          "columnsFrom": ["beatmap_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beatmap_stats": {
+      "name": "beatmap_stats",
+      "schema": "",
+      "columns": {
+        "beatmap_id": {
+          "name": "beatmap_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verified_game_count": {
+          "name": "verified_game_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_tournament_count": {
+          "name": "verified_tournament_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_verified_appearance": {
+          "name": "has_verified_appearance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_beatmap_stats_verified_game_count": {
+          "name": "ix_beatmap_stats_verified_game_count",
+          "columns": [
+            {
+              "expression": "verified_game_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_beatmap_stats_verified_tournament_count": {
+          "name": "ix_beatmap_stats_verified_tournament_count",
+          "columns": [
+            {
+              "expression": "verified_tournament_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "beatmap_stats_beatmap_id_beatmaps_id_fk": {
+          "name": "beatmap_stats_beatmap_id_beatmaps_id_fk",
+          "tableFrom": "beatmap_stats",
+          "tableTo": "beatmaps",
+          "columnsFrom": ["beatmap_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beatmaps": {
+      "name": "beatmaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "beatmaps_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "osu_id": {
+          "name": "osu_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranked_status": {
+          "name": "ranked_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff_name": {
+          "name": "diff_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_length": {
+          "name": "total_length",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drain_length": {
+          "name": "drain_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bpm": {
+          "name": "bpm",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_circle": {
+          "name": "count_circle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_slider": {
+          "name": "count_slider",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_spinner": {
+          "name": "count_spinner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cs": {
+          "name": "cs",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "od": {
+          "name": "od",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ar": {
+          "name": "ar",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sr": {
+          "name": "sr",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_combo": {
+          "name": "max_combo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beatmapset_id": {
+          "name": "beatmapset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_fetch_status": {
+          "name": "data_fetch_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"beatmaps\".\"diff_name\", '')), 'A')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "ix_beatmaps_beatmapset_id": {
+          "name": "ix_beatmaps_beatmapset_id",
+          "columns": [
+            {
+              "expression": "beatmapset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_beatmaps_osu_id": {
+          "name": "ix_beatmaps_osu_id",
+          "columns": [
+            {
+              "expression": "osu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_beatmaps_search_vector": {
+          "name": "ix_beatmaps_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_beatmaps_diff_name_trgm": {
+          "name": "ix_beatmaps_diff_name_trgm",
+          "columns": [
+            {
+              "expression": "diff_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_beatmaps_beatmapsets_beatmapset_id": {
+          "name": "fk_beatmaps_beatmapsets_beatmapset_id",
+          "tableFrom": "beatmaps",
+          "tableTo": "beatmapsets",
+          "columnsFrom": ["beatmapset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beatmapsets": {
+      "name": "beatmapsets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "beatmapsets_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "osu_id": {
+          "name": "osu_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist": {
+          "name": "artist",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranked_status": {
+          "name": "ranked_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranked_date": {
+          "name": "ranked_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_date": {
+          "name": "submitted_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"beatmapsets\".\"artist\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"beatmapsets\".\"title\", '')), 'A')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "ix_beatmapsets_creator_id": {
+          "name": "ix_beatmapsets_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_beatmapsets_osu_id": {
+          "name": "ix_beatmapsets_osu_id",
+          "columns": [
+            {
+              "expression": "osu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_beatmapsets_search_vector": {
+          "name": "ix_beatmapsets_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_beatmapsets_artist_trgm": {
+          "name": "ix_beatmapsets_artist_trgm",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_beatmapsets_title_trgm": {
+          "name": "ix_beatmapsets_title_trgm",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_beatmapsets_players_creator_id": {
+          "name": "fk_beatmapsets_players_creator_id",
+          "tableFrom": "beatmapsets",
+          "tableTo": "players",
+          "columnsFrom": ["creator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_reports": {
+      "name": "data_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "data_reports_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_changes": {
+          "name": "suggested_changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_user_id": {
+          "name": "reporter_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporter_viewed_at": {
+          "name": "reporter_viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_data_reports_entity_type_entity_id": {
+          "name": "ix_data_reports_entity_type_entity_id",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_data_reports_status": {
+          "name": "ix_data_reports_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_data_reports_reporter_user_id": {
+          "name": "ix_data_reports_reporter_user_id",
+          "columns": [
+            {
+              "expression": "reporter_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_data_reports_users_reporter_user_id": {
+          "name": "fk_data_reports_users_reporter_user_id",
+          "tableFrom": "data_reports",
+          "tableTo": "users",
+          "columnsFrom": ["reporter_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fk_data_reports_users_resolved_by_user_id": {
+          "name": "fk_data_reports_users_resolved_by_user_id",
+          "tableFrom": "data_reports",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.__EFMigrationsHistory": {
+      "name": "__EFMigrationsHistory",
+      "schema": "",
+      "columns": {
+        "migration_id": {
+          "name": "migration_id",
+          "type": "varchar(150)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_version": {
+          "name": "product_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filter_report_players": {
+      "name": "filter_report_players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "filter_report_players_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "filter_report_id": {
+          "name": "filter_report_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_rating": {
+          "name": "current_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournaments_played": {
+          "name": "tournaments_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matches_played": {
+          "name": "matches_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_filter_report_players_filter_report_id": {
+          "name": "ix_filter_report_players_filter_report_id",
+          "columns": [
+            {
+              "expression": "filter_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_filter_report_players_filter_report_id_player_id": {
+          "name": "ix_filter_report_players_filter_report_id_player_id",
+          "columns": [
+            {
+              "expression": "filter_report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_filter_report_players_player_id": {
+          "name": "ix_filter_report_players_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_filter_report_players_filter_reports_filter_report_id": {
+          "name": "fk_filter_report_players_filter_reports_filter_report_id",
+          "tableFrom": "filter_report_players",
+          "tableTo": "filter_reports",
+          "columnsFrom": ["filter_report_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_filter_report_players_players_player_id": {
+          "name": "fk_filter_report_players_players_player_id",
+          "tableFrom": "filter_report_players",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.filter_reports": {
+      "name": "filter_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "filter_reports_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_rating": {
+          "name": "min_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_rating": {
+          "name": "max_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tournaments_played": {
+          "name": "tournaments_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "peak_rating": {
+          "name": "peak_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matches_played": {
+          "name": "matches_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players_passed": {
+          "name": "players_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "players_failed": {
+          "name": "players_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "max_matches_played": {
+          "name": "max_matches_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tournaments_played": {
+          "name": "max_tournaments_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_filter_reports_user_id": {
+          "name": "ix_filter_reports_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_filter_reports_users_user_id": {
+          "name": "fk_filter_reports_users_user_id",
+          "tableFrom": "filter_reports",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_admin_notes": {
+      "name": "game_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_admin_notes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_game_admin_notes_admin_user_id": {
+          "name": "ix_game_admin_notes_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_admin_notes_reference_id": {
+          "name": "ix_game_admin_notes_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_admin_notes_games_reference_id": {
+          "name": "fk_game_admin_notes_games_reference_id",
+          "tableFrom": "game_admin_notes",
+          "tableTo": "games",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_game_admin_notes_users_admin_user_id": {
+          "name": "fk_game_admin_notes_users_admin_user_id",
+          "tableFrom": "game_admin_notes",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_audits": {
+      "name": "game_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_audits_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reference_id_lock": {
+          "name": "reference_id_lock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_user_id": {
+          "name": "action_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_game_audits_action_user_id": {
+          "name": "ix_game_audits_action_user_id",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_audits_action_user_id_created": {
+          "name": "ix_game_audits_action_user_id_created",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_audits_created": {
+          "name": "ix_game_audits_created",
+          "columns": [
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_audits_reference_id": {
+          "name": "ix_game_audits_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_audits_reference_id_lock": {
+          "name": "ix_game_audits_reference_id_lock",
+          "columns": [
+            {
+              "expression": "reference_id_lock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_audits_changes_gin": {
+          "name": "ix_game_audits_changes_gin",
+          "columns": [
+            {
+              "expression": "changes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_path_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_audits_games_reference_id": {
+          "name": "fk_game_audits_games_reference_id",
+          "tableFrom": "game_audits",
+          "tableTo": "games",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_rosters": {
+      "name": "game_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_rosters_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "roster": {
+          "name": "roster",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team": {
+          "name": "team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_game_rosters_game_id": {
+          "name": "ix_game_rosters_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_rosters_game_id_roster": {
+          "name": "ix_game_rosters_game_id_roster",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "roster",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_rosters_roster": {
+          "name": "ix_game_rosters_roster",
+          "columns": [
+            {
+              "expression": "roster",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "array_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_rosters_games_game_id": {
+          "name": "fk_game_rosters_games_game_id",
+          "tableFrom": "game_rosters",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_score_admin_notes": {
+      "name": "game_score_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_score_admin_notes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_game_score_admin_notes_admin_user_id": {
+          "name": "ix_game_score_admin_notes_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_admin_notes_reference_id": {
+          "name": "ix_game_score_admin_notes_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_score_admin_notes_game_scores_reference_id": {
+          "name": "fk_game_score_admin_notes_game_scores_reference_id",
+          "tableFrom": "game_score_admin_notes",
+          "tableTo": "game_scores",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_game_score_admin_notes_users_admin_user_id": {
+          "name": "fk_game_score_admin_notes_users_admin_user_id",
+          "tableFrom": "game_score_admin_notes",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_score_audits": {
+      "name": "game_score_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_score_audits_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reference_id_lock": {
+          "name": "reference_id_lock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_user_id": {
+          "name": "action_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_game_score_audits_action_user_id": {
+          "name": "ix_game_score_audits_action_user_id",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_audits_action_user_id_created": {
+          "name": "ix_game_score_audits_action_user_id_created",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_audits_created": {
+          "name": "ix_game_score_audits_created",
+          "columns": [
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_audits_reference_id": {
+          "name": "ix_game_score_audits_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_audits_reference_id_lock": {
+          "name": "ix_game_score_audits_reference_id_lock",
+          "columns": [
+            {
+              "expression": "reference_id_lock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_score_audits_changes_gin": {
+          "name": "ix_game_score_audits_changes_gin",
+          "columns": [
+            {
+              "expression": "changes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_path_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_score_audits_game_scores_reference_id": {
+          "name": "fk_game_score_audits_game_scores_reference_id",
+          "tableFrom": "game_score_audits",
+          "tableTo": "game_scores",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_scores": {
+      "name": "game_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "game_scores_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pp": {
+          "name": "pp",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_combo": {
+          "name": "max_combo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass": {
+          "name": "pass",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_perfect_combo": {
+          "name": "is_perfect_combo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_perfect": {
+          "name": "legacy_perfect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mods": {
+          "name": "mods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stat_combo_break": {
+          "name": "stat_combo_break",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_great": {
+          "name": "stat_great",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_ok": {
+          "name": "stat_ok",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_meh": {
+          "name": "stat_meh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_miss": {
+          "name": "stat_miss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_good": {
+          "name": "stat_good",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_perfect": {
+          "name": "stat_perfect",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_slider_tail_hit": {
+          "name": "stat_slider_tail_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_large_tick_hit": {
+          "name": "stat_large_tick_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_large_tick_miss": {
+          "name": "stat_large_tick_miss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_small_tick_hit": {
+          "name": "stat_small_tick_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_small_tick_miss": {
+          "name": "stat_small_tick_miss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_large_bonus": {
+          "name": "stat_large_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_small_bonus": {
+          "name": "stat_small_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_ignore_hit": {
+          "name": "stat_ignore_hit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_ignore_miss": {
+          "name": "stat_ignore_miss",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stat_legacy_combo_increase": {
+          "name": "stat_legacy_combo_increase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_total_score": {
+          "name": "legacy_total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team": {
+          "name": "team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_game_scores_game_id": {
+          "name": "ix_game_scores_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_scores_player_id": {
+          "name": "ix_game_scores_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_scores_player_id_game_id": {
+          "name": "ix_game_scores_player_id_game_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_game_scores_game_verification": {
+          "name": "ix_game_scores_game_verification",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "verification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_game_scores_games_game_id": {
+          "name": "fk_game_scores_games_game_id",
+          "tableFrom": "game_scores",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_game_scores_players_player_id": {
+          "name": "fk_game_scores_players_player_id",
+          "tableFrom": "game_scores",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "games_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "osu_id": {
+          "name": "osu_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scoring_type": {
+          "name": "scoring_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_type": {
+          "name": "team_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mods": {
+          "name": "mods",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2007-09-17 00:00:00'"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2007-09-17 00:00:00'"
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "warning_flags": {
+          "name": "warning_flags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "beatmap_id": {
+          "name": "beatmap_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_games_beatmap_id": {
+          "name": "ix_games_beatmap_id",
+          "columns": [
+            {
+              "expression": "beatmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_games_match_id": {
+          "name": "ix_games_match_id",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_games_match_id_osu_id": {
+          "name": "ix_games_match_id_osu_id",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "osu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_games_start_time": {
+          "name": "ix_games_start_time",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_games_beatmap_verification": {
+          "name": "ix_games_beatmap_verification",
+          "columns": [
+            {
+              "expression": "beatmap_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "verification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_games_beatmaps_beatmap_id": {
+          "name": "fk_games_beatmaps_beatmap_id",
+          "tableFrom": "games",
+          "tableTo": "beatmaps",
+          "columnsFrom": ["beatmap_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_games_matches_match_id": {
+          "name": "fk_games_matches_match_id",
+          "tableFrom": "games",
+          "tableTo": "matches",
+          "columnsFrom": ["match_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_beatmap_creators": {
+      "name": "join_beatmap_creators",
+      "schema": "",
+      "columns": {
+        "created_beatmaps_id": {
+          "name": "created_beatmaps_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creators_id": {
+          "name": "creators_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_join_beatmap_creators_creators_id": {
+          "name": "ix_join_beatmap_creators_creators_id",
+          "columns": [
+            {
+              "expression": "creators_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_join_beatmap_creators_beatmaps_created_beatmaps_id": {
+          "name": "fk_join_beatmap_creators_beatmaps_created_beatmaps_id",
+          "tableFrom": "join_beatmap_creators",
+          "tableTo": "beatmaps",
+          "columnsFrom": ["created_beatmaps_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_join_beatmap_creators_players_creators_id": {
+          "name": "fk_join_beatmap_creators_players_creators_id",
+          "tableFrom": "join_beatmap_creators",
+          "tableTo": "players",
+          "columnsFrom": ["creators_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_join_beatmap_creators": {
+          "name": "pk_join_beatmap_creators",
+          "columns": ["created_beatmaps_id", "creators_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.join_pooled_beatmaps": {
+      "name": "join_pooled_beatmaps",
+      "schema": "",
+      "columns": {
+        "pooled_beatmaps_id": {
+          "name": "pooled_beatmaps_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournaments_pooled_in_id": {
+          "name": "tournaments_pooled_in_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_join_pooled_beatmaps_tournaments_pooled_in_id": {
+          "name": "ix_join_pooled_beatmaps_tournaments_pooled_in_id",
+          "columns": [
+            {
+              "expression": "tournaments_pooled_in_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_join_pooled_beatmaps_beatmaps_pooled_beatmaps_id": {
+          "name": "fk_join_pooled_beatmaps_beatmaps_pooled_beatmaps_id",
+          "tableFrom": "join_pooled_beatmaps",
+          "tableTo": "beatmaps",
+          "columnsFrom": ["pooled_beatmaps_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_join_pooled_beatmaps_tournaments_tournaments_pooled_in_id": {
+          "name": "fk_join_pooled_beatmaps_tournaments_tournaments_pooled_in_id",
+          "tableFrom": "join_pooled_beatmaps",
+          "tableTo": "tournaments",
+          "columnsFrom": ["tournaments_pooled_in_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_join_pooled_beatmaps": {
+          "name": "pk_join_pooled_beatmaps",
+          "columns": ["pooled_beatmaps_id", "tournaments_pooled_in_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_template": {
+          "name": "message_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception": {
+          "name": "exception",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_event": {
+          "name": "log_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_admin_notes": {
+      "name": "match_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_admin_notes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_match_admin_notes_admin_user_id": {
+          "name": "ix_match_admin_notes_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_admin_notes_reference_id": {
+          "name": "ix_match_admin_notes_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_match_admin_notes_matches_reference_id": {
+          "name": "fk_match_admin_notes_matches_reference_id",
+          "tableFrom": "match_admin_notes",
+          "tableTo": "matches",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_match_admin_notes_users_admin_user_id": {
+          "name": "fk_match_admin_notes_users_admin_user_id",
+          "tableFrom": "match_admin_notes",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_audits": {
+      "name": "match_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_audits_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reference_id_lock": {
+          "name": "reference_id_lock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_user_id": {
+          "name": "action_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_match_audits_action_user_id": {
+          "name": "ix_match_audits_action_user_id",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_audits_action_user_id_created": {
+          "name": "ix_match_audits_action_user_id_created",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_audits_created": {
+          "name": "ix_match_audits_created",
+          "columns": [
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_audits_reference_id": {
+          "name": "ix_match_audits_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_audits_reference_id_lock": {
+          "name": "ix_match_audits_reference_id_lock",
+          "columns": [
+            {
+              "expression": "reference_id_lock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_audits_changes_gin": {
+          "name": "ix_match_audits_changes_gin",
+          "columns": [
+            {
+              "expression": "changes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_path_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_match_audits_matches_reference_id": {
+          "name": "fk_match_audits_matches_reference_id",
+          "tableFrom": "match_audits",
+          "tableTo": "matches",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_rosters": {
+      "name": "match_rosters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "match_rosters_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "roster": {
+          "name": "roster",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team": {
+          "name": "team",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_match_rosters_match_id": {
+          "name": "ix_match_rosters_match_id",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_rosters_match_id_roster": {
+          "name": "ix_match_rosters_match_id_roster",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "roster",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_match_rosters_roster": {
+          "name": "ix_match_rosters_roster",
+          "columns": [
+            {
+              "expression": "roster",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "array_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_match_rosters_matches_match_id": {
+          "name": "fk_match_rosters_matches_match_id",
+          "tableFrom": "match_rosters",
+          "tableTo": "matches",
+          "columnsFrom": ["match_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "matches_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "osu_id": {
+          "name": "osu_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', \"matches\".\"name\"), 'A') || setweight(to_tsvector('simple', regexp_replace(\"matches\".\"name\", '([A-Za-z]+)([0-9]+)', '\\1 \\2', 'g')), 'B')",
+            "type": "stored"
+          }
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "warning_flags": {
+          "name": "warning_flags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_lazer": {
+          "name": "is_lazer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_user_id": {
+          "name": "verified_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_fetch_status": {
+          "name": "data_fetch_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ix_matches_osu_id_is_lazer": {
+          "name": "ix_matches_osu_id_is_lazer",
+          "columns": [
+            {
+              "expression": "osu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            },
+            {
+              "expression": "is_lazer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "bool_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_matches_submitted_by_user_id": {
+          "name": "ix_matches_submitted_by_user_id",
+          "columns": [
+            {
+              "expression": "submitted_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_matches_tournament_id": {
+          "name": "ix_matches_tournament_id",
+          "columns": [
+            {
+              "expression": "tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_matches_verified_by_user_id": {
+          "name": "ix_matches_verified_by_user_id",
+          "columns": [
+            {
+              "expression": "verified_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_matches_search_vector": {
+          "name": "ix_matches_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_matches_name_trgm": {
+          "name": "ix_matches_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_matches_tournaments_tournament_id": {
+          "name": "fk_matches_tournaments_tournament_id",
+          "tableFrom": "matches",
+          "tableTo": "tournaments",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_matches_users_submitted_by_user_id": {
+          "name": "fk_matches_users_submitted_by_user_id",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fk_matches_users_verified_by_user_id": {
+          "name": "fk_matches_users_verified_by_user_id",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": ["verified_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.o_auth_client_admin_note": {
+      "name": "o_auth_client_admin_note",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "o_auth_client_admin_note_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_o_auth_client_admin_note_reference_id": {
+          "name": "ix_o_auth_client_admin_note_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_o_auth_client_admin_note_o_auth_clients_reference_id": {
+          "name": "fk_o_auth_client_admin_note_o_auth_clients_reference_id",
+          "tableFrom": "o_auth_client_admin_note",
+          "tableTo": "o_auth_clients",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.o_auth_clients": {
+      "name": "o_auth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "o_auth_clients_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_o_auth_clients_user_id": {
+          "name": "ix_o_auth_clients_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_o_auth_clients_users_user_id": {
+          "name": "fk_o_auth_clients_users_user_id",
+          "tableFrom": "o_auth_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_admin_notes": {
+      "name": "player_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_admin_notes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ix_player_admin_notes_admin_user_id": {
+          "name": "ix_player_admin_notes_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_admin_notes_reference_id": {
+          "name": "ix_player_admin_notes_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_admin_notes_players_reference_id": {
+          "name": "fk_player_admin_notes_players_reference_id",
+          "tableFrom": "player_admin_notes",
+          "tableTo": "players",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_player_admin_notes_users_admin_user_id": {
+          "name": "fk_player_admin_notes_users_admin_user_id",
+          "tableFrom": "player_admin_notes",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_friends": {
+      "name": "player_friends",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutual": {
+          "name": "mutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ix_player_friends_friend_id": {
+          "name": "ix_player_friends_friend_id",
+          "columns": [
+            {
+              "expression": "friend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_friends_player_id_players_id_fk": {
+          "name": "player_friends_player_id_players_id_fk",
+          "tableFrom": "player_friends",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_friends_friend_id_players_id_fk": {
+          "name": "player_friends_friend_id_players_id_fk",
+          "tableFrom": "player_friends",
+          "tableTo": "players",
+          "columnsFrom": ["friend_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_friends_player_id_friend_id_pk": {
+          "name": "player_friends_player_id_friend_id_pk",
+          "columns": ["player_id", "friend_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_highest_ranks": {
+      "name": "player_highest_ranks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_highest_ranks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_rank": {
+          "name": "global_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_rank_date": {
+          "name": "global_rank_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_rank": {
+          "name": "country_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_rank_date": {
+          "name": "country_rank_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_player_highest_ranks_country_rank": {
+          "name": "ix_player_highest_ranks_country_rank",
+          "columns": [
+            {
+              "expression": "country_rank",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_highest_ranks_global_rank": {
+          "name": "ix_player_highest_ranks_global_rank",
+          "columns": [
+            {
+              "expression": "global_rank",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_highest_ranks_player_id_ruleset": {
+          "name": "ix_player_highest_ranks_player_id_ruleset",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_highest_ranks_players_player_id": {
+          "name": "fk_player_highest_ranks_players_player_id",
+          "tableFrom": "player_highest_ranks",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_match_stats": {
+      "name": "player_match_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_match_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "match_cost": {
+          "name": "match_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_placement": {
+          "name": "average_placement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_misses": {
+          "name": "average_misses",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_accuracy": {
+          "name": "average_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_won": {
+          "name": "games_won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_lost": {
+          "name": "games_lost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "won": {
+          "name": "won",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teammate_ids": {
+          "name": "teammate_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opponent_ids": {
+          "name": "opponent_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_player_match_stats_match_id": {
+          "name": "ix_player_match_stats_match_id",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_match_stats_player_id": {
+          "name": "ix_player_match_stats_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_match_stats_player_id_match_id": {
+          "name": "ix_player_match_stats_player_id_match_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_match_stats_player_id_won": {
+          "name": "ix_player_match_stats_player_id_won",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "bool_ops"
+            },
+            {
+              "expression": "won",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "bool_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_match_stats_matches_match_id": {
+          "name": "fk_player_match_stats_matches_match_id",
+          "tableFrom": "player_match_stats",
+          "tableTo": "matches",
+          "columnsFrom": ["match_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_player_match_stats_players_player_id": {
+          "name": "fk_player_match_stats_players_player_id",
+          "tableFrom": "player_match_stats",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_osu_ruleset_data": {
+      "name": "player_osu_ruleset_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_osu_ruleset_data_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pp": {
+          "name": "pp",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_rank": {
+          "name": "global_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earliest_global_rank": {
+          "name": "earliest_global_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "earliest_global_rank_date": {
+          "name": "earliest_global_rank_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_player_osu_ruleset_data_player_id_ruleset": {
+          "name": "ix_player_osu_ruleset_data_player_id_ruleset",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_osu_ruleset_data_player_id_ruleset_global_rank": {
+          "name": "ix_player_osu_ruleset_data_player_id_ruleset_global_rank",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "global_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_osu_ruleset_data_players_player_id": {
+          "name": "fk_player_osu_ruleset_data_players_player_id",
+          "tableFrom": "player_osu_ruleset_data",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_ratings": {
+      "name": "player_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_ratings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volatility": {
+          "name": "volatility",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "global_rank": {
+          "name": "global_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_rank": {
+          "name": "country_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_player_ratings_player_id": {
+          "name": "ix_player_ratings_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_ratings_player_id_ruleset": {
+          "name": "ix_player_ratings_player_id_ruleset",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_ratings_rating": {
+          "name": "ix_player_ratings_rating",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "float8_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_ratings_ruleset": {
+          "name": "ix_player_ratings_ruleset",
+          "columns": [
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_ratings_ruleset_rating": {
+          "name": "ix_player_ratings_ruleset_rating",
+          "columns": [
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first",
+              "opclass": "float8_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_ratings_players_player_id": {
+          "name": "fk_player_ratings_players_player_id",
+          "tableFrom": "player_ratings",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_tournament_stats": {
+      "name": "player_tournament_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "player_tournament_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "average_rating_delta": {
+          "name": "average_rating_delta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_match_cost": {
+          "name": "average_match_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_score": {
+          "name": "average_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_placement": {
+          "name": "average_placement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_accuracy": {
+          "name": "average_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matches_played": {
+          "name": "matches_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matches_won": {
+          "name": "matches_won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matches_lost": {
+          "name": "matches_lost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_won": {
+          "name": "games_won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_lost": {
+          "name": "games_lost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teammate_ids": {
+          "name": "teammate_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "match_win_rate": {
+          "name": "match_win_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ix_player_tournament_stats_player_id_tournament_id": {
+          "name": "ix_player_tournament_stats_player_id_tournament_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_player_tournament_stats_tournament_id": {
+          "name": "ix_player_tournament_stats_tournament_id",
+          "columns": [
+            {
+              "expression": "tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_player_tournament_stats_players_player_id": {
+          "name": "fk_player_tournament_stats_players_player_id",
+          "tableFrom": "player_tournament_stats",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_player_tournament_stats_tournaments_tournament_id": {
+          "name": "fk_player_tournament_stats_tournaments_tournament_id",
+          "tableFrom": "player_tournament_stats",
+          "tableTo": "tournaments",
+          "columnsFrom": ["tournament_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "players_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "osu_id": {
+          "name": "osu_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', \"players\".\"username\"), 'A')",
+            "type": "stored"
+          }
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "default_ruleset": {
+          "name": "default_ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "osu_last_fetch": {
+          "name": "osu_last_fetch",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2007-09-17 00:00:00'"
+        },
+        "osu_track_last_fetch": {
+          "name": "osu_track_last_fetch",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osu_track_data_fetch_status": {
+          "name": "osu_track_data_fetch_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data_fetch_status": {
+          "name": "data_fetch_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_players_country": {
+          "name": "ix_players_country",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_players_search_vector": {
+          "name": "ix_players_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_players_username_trgm": {
+          "name": "ix_players_username_trgm",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_players_osu_id": {
+          "name": "ix_players_osu_id",
+          "columns": [
+            {
+              "expression": "osu_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int8_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rating_adjustments": {
+      "name": "rating_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "rating_adjustments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "adjustment_type": {
+          "name": "adjustment_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_before": {
+          "name": "rating_before",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_after": {
+          "name": "rating_after",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volatility_before": {
+          "name": "volatility_before",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volatility_after": {
+          "name": "volatility_after",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_rating_id": {
+          "name": "player_rating_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_rating_adjustments_match_id": {
+          "name": "ix_rating_adjustments_match_id",
+          "columns": [
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_rating_adjustments_player_id_match_id": {
+          "name": "ix_rating_adjustments_player_id_match_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "match_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_rating_adjustments_player_id_timestamp": {
+          "name": "ix_rating_adjustments_player_id_timestamp",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_rating_adjustments_player_rating_id": {
+          "name": "ix_rating_adjustments_player_rating_id",
+          "columns": [
+            {
+              "expression": "player_rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_rating_adjustments_matches_match_id": {
+          "name": "fk_rating_adjustments_matches_match_id",
+          "tableFrom": "rating_adjustments",
+          "tableTo": "matches",
+          "columnsFrom": ["match_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_rating_adjustments_player_ratings_player_rating_id": {
+          "name": "fk_rating_adjustments_player_ratings_player_rating_id",
+          "tableFrom": "rating_adjustments",
+          "tableTo": "player_ratings",
+          "columnsFrom": ["player_rating_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_rating_adjustments_players_player_id": {
+          "name": "fk_rating_adjustments_players_player_id",
+          "tableFrom": "rating_adjustments",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_admin_notes": {
+      "name": "tournament_admin_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_admin_notes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_tournament_admin_notes_admin_user_id": {
+          "name": "ix_tournament_admin_notes_admin_user_id",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_admin_notes_reference_id": {
+          "name": "ix_tournament_admin_notes_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_tournament_admin_notes_tournaments_reference_id": {
+          "name": "fk_tournament_admin_notes_tournaments_reference_id",
+          "tableFrom": "tournament_admin_notes",
+          "tableTo": "tournaments",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fk_tournament_admin_notes_users_admin_user_id": {
+          "name": "fk_tournament_admin_notes_users_admin_user_id",
+          "tableFrom": "tournament_admin_notes",
+          "tableTo": "users",
+          "columnsFrom": ["admin_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournament_audits": {
+      "name": "tournament_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournament_audits_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reference_id_lock": {
+          "name": "reference_id_lock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_user_id": {
+          "name": "action_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_tournament_audits_action_user_id": {
+          "name": "ix_tournament_audits_action_user_id",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_audits_action_user_id_created": {
+          "name": "ix_tournament_audits_action_user_id_created",
+          "columns": [
+            {
+              "expression": "action_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_audits_created": {
+          "name": "ix_tournament_audits_created",
+          "columns": [
+            {
+              "expression": "created",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_audits_reference_id": {
+          "name": "ix_tournament_audits_reference_id",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_audits_reference_id_lock": {
+          "name": "ix_tournament_audits_reference_id_lock",
+          "columns": [
+            {
+              "expression": "reference_id_lock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournament_audits_changes_gin": {
+          "name": "ix_tournament_audits_changes_gin",
+          "columns": [
+            {
+              "expression": "changes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_path_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_tournament_audits_tournaments_reference_id": {
+          "name": "fk_tournament_audits_tournaments_reference_id",
+          "tableFrom": "tournament_audits",
+          "tableTo": "tournaments",
+          "columnsFrom": ["reference_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tournaments": {
+      "name": "tournaments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tournaments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviation": {
+          "name": "abbreviation",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', \"tournaments\".\"name\"), 'A') || setweight(to_tsvector('simple', regexp_replace(\"tournaments\".\"name\", '([A-Za-z]+)([0-9]+)', '\\1 \\2', 'g')), 'B') || setweight(to_tsvector('simple', \"tournaments\".\"abbreviation\"), 'A')",
+            "type": "stored"
+          }
+        },
+        "forum_url": {
+          "name": "forum_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank_range_lower_bound": {
+          "name": "rank_range_lower_bound",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ruleset": {
+          "name": "ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lobby_size": {
+          "name": "lobby_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_lazer": {
+          "name": "is_lazer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by_user_id": {
+          "name": "verified_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_tournaments_name_abbreviation": {
+          "name": "ix_tournaments_name_abbreviation",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "abbreviation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournaments_ruleset": {
+          "name": "ix_tournaments_ruleset",
+          "columns": [
+            {
+              "expression": "ruleset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournaments_search_vector": {
+          "name": "ix_tournaments_search_vector",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_tournaments_name_trgm": {
+          "name": "ix_tournaments_name_trgm",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_tournaments_abbreviation_trgm": {
+          "name": "ix_tournaments_abbreviation_trgm",
+          "columns": [
+            {
+              "expression": "abbreviation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_tournaments_submitted_by_user_id": {
+          "name": "ix_tournaments_submitted_by_user_id",
+          "columns": [
+            {
+              "expression": "submitted_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_tournaments_verified_by_user_id": {
+          "name": "ix_tournaments_verified_by_user_id",
+          "columns": [
+            {
+              "expression": "verified_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_tournaments_users_submitted_by_user_id": {
+          "name": "fk_tournaments_users_submitted_by_user_id",
+          "tableFrom": "tournaments",
+          "tableTo": "users",
+          "columnsFrom": ["submitted_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fk_tournaments_users_verified_by_user_id": {
+          "name": "fk_tournaments_users_verified_by_user_id",
+          "tableFrom": "tournaments",
+          "tableTo": "users",
+          "columnsFrom": ["verified_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "default_ruleset": {
+          "name": "default_ruleset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_ruleset_is_controlled": {
+          "name": "default_ruleset_is_controlled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_user_settings_user_id": {
+          "name": "ix_user_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_user_settings_users_user_id": {
+          "name": "fk_user_settings_users_user_id",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"RAY\"}'"
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_viewed_reports_at": {
+          "name": "last_viewed_reports_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_users_player_id": {
+          "name": "ix_users_player_id",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_users_players_player_id": {
+          "name": "fk_users_players_player_id",
+          "tableFrom": "users",
+          "tableTo": "players",
+          "columnsFrom": ["player_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1781579582951,
       "tag": "0017_api_keys_reference_id",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1782011749454,
+      "tag": "0018_soft_miek",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/e2e/fixtures/orpc.ts
+++ b/apps/web/e2e/fixtures/orpc.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+import type { RouterClient } from '@orpc/server';
+
+import type { router } from '../../app/server/oRPC/router';
+import { STORAGE_STATE, type TestRole } from './auth';
+
+const BASE_URL = 'http://localhost:3001';
+
+/**
+ * Builds a `Cookie` header from a Playwright storage-state file so server calls
+ * carry the same authenticated session the browser project uses.
+ */
+function cookieHeaderFromStorageState(path: string): string {
+  const state = JSON.parse(readFileSync(path, 'utf8')) as {
+    cookies?: Array<{ name: string; value: string }>;
+  };
+  return (state.cookies ?? [])
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join('; ');
+}
+
+/**
+ * Creates an oRPC client authenticated as the given test role. Used by specs that
+ * need to seed deterministic server state (e.g. an admin-resolved report) before
+ * asserting on the UI. Read the storage state lazily — the setup project writes it
+ * before tests run, but after test files are collected.
+ */
+export function createOrpcClientForRole(
+  role: TestRole
+): RouterClient<typeof router> {
+  const cookie = cookieHeaderFromStorageState(STORAGE_STATE[role]);
+  const link = new RPCLink({
+    url: `${BASE_URL}/rpc`,
+    headers: () => ({ cookie }),
+  });
+  return createORPCClient(link);
+}

--- a/apps/web/e2e/fixtures/test-config.ts
+++ b/apps/web/e2e/fixtures/test-config.ts
@@ -32,6 +32,7 @@ export const ROUTES = {
   beatmap: (id: number) => `/beatmaps/${id}`,
   match: (id: number) => `/matches/${id}`,
   settings: '/settings',
+  reports: '/reports',
   admin: '/admin',
   adminReports: '/admin/reports',
   filter: '/tools/filter',

--- a/apps/web/e2e/reports.e2e.ts
+++ b/apps/web/e2e/reports.e2e.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import { ReportEntityType, ReportStatus } from '@otr/core/osu';
+
+import { STORAGE_STATE } from './fixtures/auth';
+import { createOrpcClientForRole } from './fixtures/orpc';
+import { ROUTES, TEST_TOURNAMENT_ID } from './fixtures/test-config';
+
+/**
+ * Read-only "Your Reports" view for regular users. Covers access control
+ * (logged-out / admin / user), profile-menu visibility, and the core unread
+ * admin-update indicator: a dot appears for a resolved report and clears once
+ * the reporter opens it. The unread spec seeds its own data via oRPC (create as
+ * the user, resolve as an admin) so it does not depend on pre-existing rows.
+ */
+test.describe('Your Reports', () => {
+  test.describe('Unauthenticated access', () => {
+    test('redirects an unauthenticated visitor to /unauthorized', async ({
+      page,
+    }) => {
+      await page.goto(ROUTES.reports);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page).toHaveURL(/\/unauthorized/, { timeout: 10000 });
+    });
+  });
+
+  test.describe('Admin role', () => {
+    test.use({ storageState: STORAGE_STATE.admin });
+
+    test('is redirected to the admin reports view', async ({ page }) => {
+      await page.goto(ROUTES.reports);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page).toHaveURL(/\/admin\/reports/, { timeout: 10000 });
+      await expect(
+        page.locator('[data-testid="admin-reports-heading"]')
+      ).toBeVisible({ timeout: 10000 });
+    });
+  });
+
+  test.describe('Regular user role', () => {
+    test.use({ storageState: STORAGE_STATE.user });
+
+    test('renders the Your Reports heading and card', async ({ page }) => {
+      await page.goto(ROUTES.reports);
+      await page.waitForLoadState('networkidle');
+
+      await expect(
+        page.getByRole('heading', { level: 1, name: 'Your Reports' })
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('[data-testid="my-reports-card"]')).toBeVisible(
+        { timeout: 10000 }
+      );
+    });
+
+    test('the profile menu exposes Reports (and not Admin) for a regular user', async ({
+      page,
+    }) => {
+      await page.goto(ROUTES.home);
+      await page.waitForLoadState('networkidle');
+
+      await page
+        .getByRole('banner')
+        .getByRole('img', { name: /avatar$/i })
+        .click();
+
+      const reportsItem = page.getByRole('menuitem', { name: 'Reports' });
+      await expect(reportsItem).toBeVisible({ timeout: 10000 });
+      await expect(reportsItem).toHaveAttribute('href', ROUTES.reports);
+      await expect(page.getByRole('menuitem', { name: 'Admin' })).toHaveCount(
+        0
+      );
+    });
+
+    test('an unread admin update shows a dot that clears when the report is opened', async ({
+      page,
+    }) => {
+      // Arrange: create a report as the user, then resolve it as an admin. A
+      // resolved report the reporter has not yet viewed is "unread".
+      const userClient = createOrpcClientForRole('user');
+      const adminClient = createOrpcClientForRole('admin');
+
+      const created = await userClient.reports.create({
+        entityType: ReportEntityType.Tournament,
+        entityId: TEST_TOURNAMENT_ID,
+        suggestedChanges: { name: 'E2E unread-indicator probe' },
+        justification: 'E2E: verifying the unread admin-update indicator',
+      });
+      expect(created.reportId).toBeGreaterThan(0);
+
+      await adminClient.reports.resolve({
+        reportId: created.reportId!,
+        status: ReportStatus.Approved,
+        adminNote: 'E2E admin response',
+      });
+
+      // Act: view the reports list. The freshly resolved report is the newest,
+      // so it is the first row and must carry the unread dot.
+      await page.goto(ROUTES.reports);
+      await page.waitForLoadState('networkidle');
+
+      const dots = page.locator('[data-testid="my-reports-unread-dot"]');
+      const before = await dots.count();
+      expect(before).toBeGreaterThan(0);
+
+      const firstRow = page.locator('[data-testid="my-reports-row"]').first();
+      await expect(
+        firstRow.locator('[data-testid="my-reports-unread-dot"]')
+      ).toBeVisible({ timeout: 10000 });
+      await firstRow.click();
+
+      // Assert: the detail view is read-only and surfaces the admin response.
+      const dialog = page.locator('[data-testid="my-report-detail"]');
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+      await expect(
+        dialog.getByText('Admin Response', { exact: true })
+      ).toBeVisible();
+      await expect(dialog.getByText('E2E admin response')).toBeVisible();
+      await expect(
+        dialog.getByRole('button', { name: /confirm|dismiss|reopen/i })
+      ).toHaveCount(0);
+
+      // Closing the report acknowledges the update: one fewer dot, and it stays
+      // cleared after a reload (the view timestamp is persisted server-side).
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+      await expect(dots).toHaveCount(before - 1, { timeout: 10000 });
+
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await expect(
+        page.locator('[data-testid="my-reports-unread-dot"]')
+      ).toHaveCount(before - 1, { timeout: 10000 });
+    });
+  });
+});

--- a/apps/web/lib/orpc/schema/report.ts
+++ b/apps/web/lib/orpc/schema/report.ts
@@ -116,6 +116,28 @@ export const ReportListResponseSchema = z.object({
   totalCount: z.number().int().nonnegative(),
 });
 
+/**
+ * Read-only view of a report for the user who created it. Intentionally omits
+ * reporter/resolver identity and exposes whether an admin update is unread.
+ */
+export const MyReportSchema = reportBaseSchema.extend({
+  entityDisplayName: z.string(),
+  matchId: z.number().int().positive().optional(),
+  hasUnreadUpdate: z.boolean(),
+});
+
+export const MyReportListResponseSchema = z.object({
+  reports: z.array(MyReportSchema),
+});
+
+export const MarkReportViewedInputSchema = z.object({
+  reportId: z.number().int().positive(),
+});
+
+export const MyUnreadReportCountResponseSchema = z.object({
+  count: z.number().int().nonnegative(),
+});
+
 export const ReportMutationResponseSchema = z.object({
   success: z.boolean(),
   reportId: z.number().int().positive().optional(),
@@ -138,4 +160,11 @@ export const UnseenReportCountResponseSchema = z.object({
 
 export type UnseenReportCountResponse = z.infer<
   typeof UnseenReportCountResponseSchema
+>;
+
+export type MyReport = z.infer<typeof MyReportSchema>;
+export type MyReportListResponse = z.infer<typeof MyReportListResponseSchema>;
+export type MarkReportViewedInput = z.infer<typeof MarkReportViewedInputSchema>;
+export type MyUnreadReportCountResponse = z.infer<
+  typeof MyUnreadReportCountResponseSchema
 >;

--- a/packages/otr-core/src/db/schema.ts
+++ b/packages/otr-core/src/db/schema.ts
@@ -1878,6 +1878,10 @@ export const dataReports = pgTable(
       withTimezone: true,
       mode: 'string',
     }),
+    reporterViewedAt: timestamp('reporter_viewed_at', {
+      withTimezone: true,
+      mode: 'string',
+    }),
   },
   (table) => [
     index('ix_data_reports_entity_type_entity_id').using(


### PR DESCRIPTION
closes #734

- Adds a read-only `/reports` page where non-admin users can track the status of reports they submitted; admins are redirected to `/admin/reports`.
- Shows a blue dot on the profile menu and avatar when a user has an unread admin update, cleared per-report once they open it.
- Tracks unread state via a new `reporter_viewed_at` column on `data_reports`, backed by three new `reports/me` oRPC endpoints.
- Adds Playwright e2e coverage.