### PR TITLE
Disable registrant filtering during rating window

### DIFF
--- a/apps/web/app/server/oRPC/procedures/base.ts
+++ b/apps/web/app/server/oRPC/procedures/base.ts
@@ -712,7 +712,7 @@ export const protectedProcedure = base
 // against. See issue #763.
 const withMaintenanceWindowGuard = base.middleware(
   async ({ context, next }) => {
-    assertOutsideMaintenanceWindow(context.headers);
+    await assertOutsideMaintenanceWindow(context.headers);
     return next();
   }
 );

--- a/apps/web/app/server/oRPC/procedures/filteringProcedures.ts
+++ b/apps/web/app/server/oRPC/procedures/filteringProcedures.ts
@@ -8,6 +8,7 @@ import {
   VerificationStatus,
 } from '@otr/core/osu';
 import { protectedProcedure, publicProcedure } from './base';
+import { assertOutsideMaintenanceWindow } from './shared/maintenanceWindow';
 import {
   FilterReportSchema,
   FilteringRequestSchema,
@@ -44,6 +45,8 @@ export const filterRegistrants = protectedProcedure
         message: 'User account is not linked to an internal profile',
       });
     }
+
+    await assertOutsideMaintenanceWindow(context.headers, context.db);
 
     const uniqueOsuIds = Array.from(new Set(input.osuPlayerIds));
 
@@ -276,6 +279,10 @@ export const filterRegistrants = protectedProcedure
     const playersFailed = playerResults.length - playersPassed;
 
     const insertedReport = await context.db.transaction(async (tx) => {
+      // Re-assert with the transaction clock so the check matches the
+      // report's `created` timestamp exactly.
+      await assertOutsideMaintenanceWindow(context.headers, tx);
+
       const [report] = await tx
         .insert(schema.filterReports)
         .values({
@@ -293,6 +300,7 @@ export const filterRegistrants = protectedProcedure
         })
         .returning({
           id: schema.filterReports.id,
+          created: schema.filterReports.created,
         });
 
       if (!report) {
@@ -326,6 +334,7 @@ export const filterRegistrants = protectedProcedure
 
     return {
       filterReportId: insertedReport.id,
+      created: insertedReport.created,
       playersPassed,
       playersFailed,
       filteringResults: playerResults,
@@ -364,6 +373,7 @@ export const getFilterReport = publicProcedure
 
     const response = {
       filterReportId: report.id,
+      created: report.created,
       playersPassed: report.playersPassed,
       playersFailed: report.playersFailed,
       filteringResults: playerEntries.map((player) => ({

--- a/apps/web/app/server/oRPC/procedures/shared/maintenanceWindow.ts
+++ b/apps/web/app/server/oRPC/procedures/shared/maintenanceWindow.ts
@@ -5,9 +5,8 @@ import { readRatingTimestamps, type DbReader } from '@/lib/db/rating-utils';
 import { resolveMaintenanceWindowActive } from '@/lib/maintenance-window';
 
 /**
- * Throws a 503 when the maintenance window is active. With a database handle
- * the window tracks the actual rating recalculation instead of the wall
- * clock.
+ * Throws a 503 when the maintenance window is active. If a DbReader is passed,
+ * the window looks for a rating timestamp that is newer than the window start.
  */
 export const assertOutsideMaintenanceWindow = async (
   headers: Headers,

--- a/apps/web/app/server/oRPC/procedures/shared/maintenanceWindow.ts
+++ b/apps/web/app/server/oRPC/procedures/shared/maintenanceWindow.ts
@@ -1,14 +1,21 @@
 import { ORPCError } from '@orpc/server';
 import { MAINTENANCE_WINDOW_LABEL } from '@otr/core/maintenance';
 
+import { readRatingTimestamps, type DbReader } from '@/lib/db/rating-utils';
 import { resolveMaintenanceWindowActive } from '@/lib/maintenance-window';
 
 /**
- * Throws a 503 when the maintenance window is active. Used to gate admin
- * mutations on tournament data during the weekly processor run.
+ * Throws a 503 when the maintenance window is active. With a database handle
+ * the window tracks the actual rating recalculation instead of the wall
+ * clock.
  */
-export const assertOutsideMaintenanceWindow = (headers: Headers): void => {
-  if (!resolveMaintenanceWindowActive(headers)) {
+export const assertOutsideMaintenanceWindow = async (
+  headers: Headers,
+  db?: DbReader
+): Promise<void> => {
+  const ratingTimestamps = db ? await readRatingTimestamps(db) : undefined;
+
+  if (!resolveMaintenanceWindowActive(headers, ratingTimestamps)) {
     return;
   }
 

--- a/apps/web/app/tools/filter/FilteringPageClient.tsx
+++ b/apps/web/app/tools/filter/FilteringPageClient.tsx
@@ -2,12 +2,19 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Clock } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import FilteringForm from '@/components/filtering/FilteringForm';
 import { FilteringResult } from '@/lib/orpc/schema/filtering';
 
-export default function FilteringPageClient() {
+type FilteringPageClientProps = {
+  /** True while ratings are recalculating and filtering is blocked. */
+  filterBlocked: boolean;
+};
+
+export default function FilteringPageClient({
+  filterBlocked,
+}: FilteringPageClientProps) {
   const [filteringResults, setFilteringResults] =
     useState<FilteringResult | null>(null);
 
@@ -63,10 +70,27 @@ export default function FilteringPageClient() {
           </div>
         </AlertDescription>
       </Alert>
-      <FilteringForm
-        onFilteringComplete={setFilteringResults}
-        filteringResults={filteringResults}
-      />
+      {filterBlocked ? (
+        <Alert
+          data-testid="filtering-unavailable"
+          className="border-orange-500/50 bg-orange-500/15"
+        >
+          <Clock className="h-4 w-4 text-orange-800 dark:text-orange-200" />
+          <AlertTitle className="font-bold text-orange-800 dark:text-orange-200">
+            Filtering is temporarily unavailable
+          </AlertTitle>
+          <AlertDescription className="text-orange-800/90 dark:text-orange-200/90">
+            <p className="mt-2">
+              Ratings are currently recalculating, please check back later.
+            </p>
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <FilteringForm
+          onFilteringComplete={setFilteringResults}
+          filteringResults={filteringResults}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/tools/filter/page.tsx
+++ b/apps/web/app/tools/filter/page.tsx
@@ -1,6 +1,9 @@
 import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { auth } from '@/lib/auth/auth';
+import { db } from '@/lib/db';
+import { readRatingTimestamps } from '@/lib/db/rating-utils';
+import { resolveMaintenanceWindowActive } from '@/lib/maintenance-window';
 import FilteringPageClient from '@/app/tools/filter/FilteringPageClient';
 
 export default async function FilteringPage() {
@@ -11,5 +14,10 @@ export default async function FilteringPage() {
     redirect('/unauthorized');
   }
 
-  return <FilteringPageClient />;
+  const filterBlocked = resolveMaintenanceWindowActive(
+    headersList,
+    await readRatingTimestamps(db)
+  );
+
+  return <FilteringPageClient filterBlocked={filterBlocked} />;
 }

--- a/apps/web/components/filtering/FilterComplianceNotice.tsx
+++ b/apps/web/components/filtering/FilterComplianceNotice.tsx
@@ -3,31 +3,25 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Info, Calendar, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 interface FilterComplianceNoticeProps {
   filterReportId: number;
+  /** Server-side creation timestamp of the report (`filter_reports.created`). */
+  created: string;
 }
 
 export default function FilterComplianceNotice({
   filterReportId,
+  created,
 }: FilterComplianceNoticeProps) {
   const [copied, setCopied] = useState(false);
-  const [dateTimeString, setDateTimeString] = useState<string>('');
-  const [forumPostString, setForumPostString] = useState<string>('');
 
-  useEffect(() => {
-    // Generate date string on client side to avoid hydration mismatch
-    const now = new Date();
-    const utcDate = now.toISOString().slice(0, 10); // YYYY-MM-DD
-    const utcTime = now.toISOString().slice(11, 19); // HH:MM:SS
-    const dateTime = `${utcDate} ${utcTime} UTC`;
-    setDateTimeString(dateTime);
-    setForumPostString(
-      `o!TR Filtering performed at: ${dateTime} (Report ID: ${filterReportId})`
-    );
-  }, [filterReportId]);
+  // Use the stored report timestamp, never the browser clock.
+  const createdIso = new Date(created).toISOString();
+  const dateTimeString = `${createdIso.slice(0, 10)} ${createdIso.slice(11, 19)} UTC`;
+  const forumPostString = `o!TR Filtering performed at: ${dateTimeString} (Report ID: ${filterReportId})`;
 
   const handleCopy = async () => {
     try {
@@ -56,7 +50,7 @@ export default function FilterComplianceNotice({
                   <span>Performed at</span>
                 </div>
                 <p className="font-mono text-sm font-medium">
-                  {dateTimeString || 'Loading...'}
+                  {dateTimeString}
                 </p>
               </div>
 
@@ -82,7 +76,6 @@ export default function FilterComplianceNotice({
                   size="icon"
                   onClick={handleCopy}
                   className="h-8 w-8 flex-shrink-0"
-                  disabled={!forumPostString}
                   title="Copy to clipboard"
                 >
                   {copied ? (

--- a/apps/web/components/filtering/FilterReportView.tsx
+++ b/apps/web/components/filtering/FilterReportView.tsx
@@ -116,7 +116,7 @@ export function FilterReportView() {
       player.username || 'N/A',
       player.playerId?.toString() || 'N/A',
       player.isSuccess ? 'Passed' : 'Failed',
-      player.currentRating != null ? player.currentRating.toFixed(2) : 'N/A',
+      player.currentRating != null ? player.currentRating.toString() : 'N/A',
       getFailureReasons(player.failureReason ?? undefined).join(', '),
     ]);
 

--- a/apps/web/components/filtering/FilteringForm.tsx
+++ b/apps/web/components/filtering/FilteringForm.tsx
@@ -279,7 +279,7 @@ export default function FilteringForm({
           result.playerId?.toString() || 'N/A',
           result.isSuccess ? 'Passed' : 'Failed',
           result.currentRating != null
-            ? result.currentRating.toFixed(0)
+            ? result.currentRating.toString()
             : 'N/A',
           failureReasons.join(', '),
         ];

--- a/apps/web/components/filtering/FilteringForm.tsx
+++ b/apps/web/components/filtering/FilteringForm.tsx
@@ -417,6 +417,7 @@ export default function FilteringForm({
         <div data-testid="filter-results">
           <FilterComplianceNotice
             filterReportId={filteringResults.filterReportId}
+            created={filteringResults.created}
           />
           <FilteringResultsTable
             results={filteringResults}

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -8,7 +8,7 @@ import { ROLE_PLAYER_ID, STORAGE_STATE, signInPlayer } from './fixtures/auth';
  * opt in with `test.use({ storageState: STORAGE_STATE.admin })`.
  */
 setup('authenticate as admin', async ({ request }) => {
-  await signInPlayer(request, ROLE_PLAYER_ID.admin);
+  await signInPlayer(request, ROLE_PLAYER_ID.admin, { admin: true });
   await request.storageState({ path: STORAGE_STATE.admin });
 });
 

--- a/apps/web/e2e/filtering.e2e.ts
+++ b/apps/web/e2e/filtering.e2e.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from 'node:fs';
+
 import { test, expect } from '@playwright/test';
+import { createORPCClient } from '@orpc/client';
+import { RPCLink } from '@orpc/client/fetch';
+
 import { STORAGE_STATE } from './fixtures/auth';
 import { ROUTES } from './fixtures/test-config';
 
@@ -91,6 +96,85 @@ test.describe('Tournament Registrant Filtering', () => {
       await textarea.fill('1234567, 2345678');
       await expect(textarea).toHaveValue('1234567, 2345678');
     });
+  });
+});
+
+test.describe('Filtering during the maintenance window', () => {
+  test.describe('Signed-in user', () => {
+    test.use({ storageState: STORAGE_STATE.user });
+
+    test('shows the unavailable state instead of the form during the window', async ({
+      page,
+    }) => {
+      await page.setExtraHTTPHeaders({
+        'x-e2e-maintenance-window': 'active',
+      });
+
+      await page.goto(ROUTES.filter);
+      await page.waitForLoadState('networkidle');
+
+      await expect(
+        page.locator('[data-testid="filtering-unavailable"]')
+      ).toContainText('Filtering is temporarily unavailable', {
+        timeout: 10000,
+      });
+      await expect(page.locator('[data-testid="filter-form"]')).toHaveCount(0);
+    });
+
+    test('shows the form outside the window', async ({ page }) => {
+      await page.setExtraHTTPHeaders({
+        'x-e2e-maintenance-window': 'inactive',
+      });
+
+      await page.goto(ROUTES.filter);
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('[data-testid="filter-form"]')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.locator('[data-testid="filtering-unavailable"]')
+      ).toHaveCount(0);
+    });
+  });
+
+  test('rejects filter submissions during the window with a 503', async ({
+    baseURL,
+  }) => {
+    // The gate runs before any lookup or write, so nothing is ever persisted.
+    const state = JSON.parse(readFileSync(STORAGE_STATE.user, 'utf-8')) as {
+      cookies: Array<{ name: string; value: string }>;
+    };
+    const cookie = state.cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+
+    const link = new RPCLink({
+      url: `${baseURL}/rpc`,
+      headers: () => ({
+        cookie,
+        'x-e2e-maintenance-window': 'active',
+      }),
+    });
+    const client = createORPCClient(link) as unknown as {
+      filtering: {
+        filter(input: {
+          ruleset: number;
+          osuPlayerIds: number[];
+        }): Promise<unknown>;
+      };
+    };
+
+    type CapturedError = { code?: string; data?: { code?: string } };
+    let captured: CapturedError | null = null;
+
+    try {
+      await client.filtering.filter({ ruleset: 0, osuPlayerIds: [1] });
+    } catch (error) {
+      captured = error as CapturedError;
+    }
+
+    expect(captured).not.toBeNull();
+    expect(captured?.code).toBe('SERVICE_UNAVAILABLE');
+    expect(captured?.data?.code).toBe('MAINTENANCE_WINDOW');
   });
 });
 

--- a/apps/web/e2e/fixtures/auth.ts
+++ b/apps/web/e2e/fixtures/auth.ts
@@ -2,10 +2,10 @@ import path from 'node:path';
 import { type APIRequestContext, type Page } from '@playwright/test';
 
 /**
- * Players that already have `auth_users` rows in the dev database. Admin status is
- * derived from each player's `users.scopes`:
- *   - 440 ("Stage")  -> scopes include `admin`  => admin session
- *   - 1068 ("D I O") -> scopes are `{whitelist}` => regular signed-in session
+ * Players used for e2e sessions. The sign-in endpoint provisions their
+ * `users`/`auth_users` rows on first use, so only the `players` rows need to exist:
+ *   - 440 ("Stage")  -> admin session
+ *   - 1068 ("D I O") -> regular signed-in session
  */
 export const TEST_ADMIN_PLAYER_ID = 440;
 export const TEST_NONADMIN_PLAYER_ID = 1068;
@@ -33,10 +33,11 @@ export const E2E_SIGN_IN_PATH = '/api/auth/e2e/sign-in';
  */
 export async function signInPlayer(
   request: APIRequestContext,
-  playerId: number
+  playerId: number,
+  options: { admin?: boolean } = {}
 ): Promise<void> {
   const response = await request.post(E2E_SIGN_IN_PATH, {
-    data: { playerId },
+    data: { playerId, admin: options.admin ?? false },
   });
 
   // Only read the body / build the message on failure — passing them to
@@ -56,7 +57,9 @@ export async function signInPlayer(
  * is scoped to the right origin, then reloads to pick up the session.
  */
 export async function loginAs(page: Page, role: TestRole): Promise<void> {
-  await signInPlayer(page.request, ROLE_PLAYER_ID[role]);
+  await signInPlayer(page.request, ROLE_PLAYER_ID[role], {
+    admin: role === 'admin',
+  });
   await page.goto('/');
   await page.waitForLoadState('networkidle');
 }

--- a/apps/web/e2e/fixtures/auth.ts
+++ b/apps/web/e2e/fixtures/auth.ts
@@ -4,10 +4,10 @@ import { type APIRequestContext, type Page } from '@playwright/test';
 /**
  * Players used for e2e sessions. The sign-in endpoint provisions their
  * `users`/`auth_users` rows on first use, so only the `players` rows need to exist:
- *   - 440 ("Stage")  -> admin session
- *   - 1068 ("D I O") -> regular signed-in session
+ *   - 3616 ("Cytusine") -> admin session
+ *   - 1068 ("D I O")    -> regular signed-in session
  */
-export const TEST_ADMIN_PLAYER_ID = 440;
+export const TEST_ADMIN_PLAYER_ID = 3616;
 export const TEST_NONADMIN_PLAYER_ID = 1068;
 
 /** Where the Playwright setup project writes each role's storage state. */

--- a/apps/web/lib/__tests__/maintenance-window.test.ts
+++ b/apps/web/lib/__tests__/maintenance-window.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { resolveMaintenanceWindowActive } from '../maintenance-window';
+
+/** Tuesday inside the window, before the processor has committed. */
+const DURING_WINDOW = new Date('2026-01-06T11:50:00Z');
+/** Rebuild from the previous week (stale relative to DURING_WINDOW). */
+const STALE_REBUILD = new Date('2025-12-30T12:04:00Z');
+/** Rebuild after this week's window start (fresh). */
+const FRESH_REBUILD = new Date('2026-01-06T12:03:00Z');
+
+const headersWith = (override?: string): Pick<Headers, 'get'> => ({
+  get: (name: string) =>
+    name === 'x-e2e-maintenance-window' ? (override ?? null) : null,
+});
+
+describe('resolveMaintenanceWindowActive with rating timestamps', () => {
+  // Widened view: the app's env typings declare these vars as required, but
+  // the tests must be able to unset them.
+  const env = process.env as Record<string, string | undefined>;
+  const originalEnv = {
+    E2E_TEST_AUTH: env.E2E_TEST_AUTH,
+    MAINTENANCE_WINDOW_ENABLED: env.MAINTENANCE_WINDOW_ENABLED,
+  };
+
+  beforeEach(() => {
+    delete env.E2E_TEST_AUTH;
+    delete env.MAINTENANCE_WINDOW_ENABLED;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete env[key];
+      } else {
+        env[key] = value;
+      }
+    }
+  });
+
+  it('is active while a recalculation is pending', () => {
+    expect(
+      resolveMaintenanceWindowActive(headersWith(), {
+        now: DURING_WINDOW,
+        latestRatingCreated: STALE_REBUILD,
+      })
+    ).toBe(true);
+  });
+
+  it('is inactive once the processor has committed, even inside the window', () => {
+    expect(
+      resolveMaintenanceWindowActive(headersWith(), {
+        now: DURING_WINDOW,
+        latestRatingCreated: FRESH_REBUILD,
+      })
+    ).toBe(false);
+  });
+
+  it('is inactive when the feature flag is disabled', () => {
+    process.env.MAINTENANCE_WINDOW_ENABLED = 'false';
+
+    expect(
+      resolveMaintenanceWindowActive(headersWith(), {
+        now: DURING_WINDOW,
+        latestRatingCreated: STALE_REBUILD,
+      })
+    ).toBe(false);
+  });
+
+  it('honors the e2e override header when test auth is enabled', () => {
+    process.env.E2E_TEST_AUTH = 'true';
+
+    expect(
+      resolveMaintenanceWindowActive(headersWith('active'), {
+        now: DURING_WINDOW,
+        latestRatingCreated: FRESH_REBUILD,
+      })
+    ).toBe(true);
+    expect(
+      resolveMaintenanceWindowActive(headersWith('inactive'), {
+        now: DURING_WINDOW,
+        latestRatingCreated: STALE_REBUILD,
+      })
+    ).toBe(false);
+  });
+
+  it('ignores the e2e override header outside test environments', () => {
+    expect(
+      resolveMaintenanceWindowActive(headersWith('active'), {
+        now: DURING_WINDOW,
+        latestRatingCreated: FRESH_REBUILD,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/lib/auth/e2e-test-auth-plugin.ts
+++ b/apps/web/lib/auth/e2e-test-auth-plugin.ts
@@ -17,9 +17,10 @@ import { db } from '@/lib/db';
  * left unset (or false) in staging/prod configs — Playwright tests the production
  * build (`next start`, NODE_ENV=production), so the gate cannot key off NODE_ENV.
  *
- * Endpoint: `POST /api/auth/e2e/sign-in` with body `{ playerId }`. The player must
- * already have an `auth_users` row (created on first real login); admin vs. non-admin
- * is derived from that user's `users.scopes`, exactly like a genuine session.
+ * Endpoint: `POST /api/auth/e2e/sign-in` with body `{ playerId, admin? }`. The player
+ * must exist; if it has no `users`/`auth_users` rows yet (e.g. the local database was
+ * restored from a dump that excludes auth tables), they are provisioned on the fly,
+ * with `admin: true` granting the `admin` scope the same way a real login would read it.
  */
 export const isE2eAuthEnabled = () => process.env.E2E_TEST_AUTH === 'true';
 
@@ -33,6 +34,7 @@ export const e2eTestAuthPlugin = () =>
           method: 'POST',
           body: z.object({
             playerId: z.number().int().positive(),
+            admin: z.boolean().optional(),
           }),
           metadata: {
             openapi: {
@@ -47,16 +49,42 @@ export const e2eTestAuthPlugin = () =>
             throw new APIError('NOT_FOUND', { message: 'Not found' });
           }
 
-          const { playerId } = ctx.body;
+          const { playerId, admin = false } = ctx.body;
 
-          const authUser = await db.query.auth_users.findFirst({
+          let authUser = await db.query.auth_users.findFirst({
             where: eq(schema.auth_users.playerId, playerId),
           });
 
           if (!authUser) {
-            throw new APIError('NOT_FOUND', {
-              message: `No auth_users record for player ${playerId}. Log in once via osu! OAuth to create it.`,
+            const player = await db.query.players.findFirst({
+              where: eq(schema.players.id, playerId),
             });
+
+            if (!player) {
+              throw new APIError('NOT_FOUND', {
+                message: `No player with id ${playerId}.`,
+              });
+            }
+
+            await db
+              .insert(schema.users)
+              .values({
+                playerId,
+                scopes: admin ? ['admin'] : ['whitelist'],
+              })
+              .onConflictDoNothing({ target: schema.users.playerId });
+
+            [authUser] = await db
+              .insert(schema.auth_users)
+              .values({
+                id: crypto.randomUUID(),
+                name: player.username,
+                email: `e2e-player-${playerId}@otr.local`,
+                emailVerified: true,
+                playerId,
+                role: admin ? 'admin' : null,
+              })
+              .returning();
           }
 
           const session = await ctx.context.internalAdapter.createSession(

--- a/apps/web/lib/db/rating-utils.ts
+++ b/apps/web/lib/db/rating-utils.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+
+import * as schema from '@otr/core/db/schema';
+
+import type { DatabaseClient } from '@/lib/db';
+import type { RatingTimestamps } from '@/lib/maintenance-window';
+
+/** Accepts both the database client and a transaction handle. */
+export type DbReader = Pick<DatabaseClient, 'select'>;
+
+/**
+ * Reads the database clock and the most recent `player_ratings.created`
+ * (the last processor run) in one query.
+ */
+export async function readRatingTimestamps(
+  db: DbReader
+): Promise<RatingTimestamps> {
+  const [row] = await db
+    .select({
+      nowEpoch: sql<string>`extract(epoch from now())`,
+      latestEpoch: sql<
+        string | null
+      >`extract(epoch from max(${schema.playerRatings.created}))`,
+    })
+    .from(schema.playerRatings);
+
+  return {
+    now: row ? new Date(Number(row.nowEpoch) * 1000) : new Date(),
+    latestRatingCreated:
+      row?.latestEpoch != null
+        ? new Date(Number(row.latestEpoch) * 1000)
+        : null,
+  };
+}

--- a/apps/web/lib/db/rating-utils.ts
+++ b/apps/web/lib/db/rating-utils.ts
@@ -9,8 +9,7 @@ import type { RatingTimestamps } from '@/lib/maintenance-window';
 export type DbReader = Pick<DatabaseClient, 'select'>;
 
 /**
- * Reads the database clock and the most recent `player_ratings.created`
- * (the last processor run) in one query.
+ * Reads the database clock and the most recent `player_ratings.created` timestamp.
  */
 export async function readRatingTimestamps(
   db: DbReader

--- a/apps/web/lib/maintenance-window.ts
+++ b/apps/web/lib/maintenance-window.ts
@@ -1,4 +1,7 @@
-import { isWithinMaintenanceWindow } from '@otr/core/maintenance';
+import {
+  isRatingRecalculationPending,
+  isWithinMaintenanceWindow,
+} from '@otr/core/maintenance';
 
 /**
  * Test-only request header used by the e2e suite to force the maintenance
@@ -15,17 +18,21 @@ const isE2eMaintenanceOverrideEnabled = () =>
 const isMaintenanceWindowEnabled = () =>
   process.env.MAINTENANCE_WINDOW_ENABLED !== 'false';
 
+export type RatingTimestamps = {
+  /** Database clock (inside a transaction: the transaction start time). */
+  now: Date;
+  /** Most recent `player_ratings.created`, or null when no ratings exist. */
+  latestRatingCreated: Date | null;
+};
+
 /**
- * Resolves whether the site should treat the maintenance window as active.
- *
- * Precedence:
- *   1. E2E override header (test environments only).
- *   2. The `MAINTENANCE_WINDOW_ENABLED` feature flag (developers disable it
- *      locally so they aren't blocked while working).
- *   3. The weekly Tuesday 11:45-12:15 UTC window.
+ * Resolves whether the maintenance window is active, after the e2e override
+ * header and the `MAINTENANCE_WINDOW_ENABLED` flag. With rating timestamps
+ * the window tracks the actual recalculation; otherwise the wall clock.
  */
 export const resolveMaintenanceWindowActive = (
-  headers: HeadersLike
+  headers: HeadersLike,
+  ratingTimestamps?: RatingTimestamps
 ): boolean => {
   if (isE2eMaintenanceOverrideEnabled()) {
     const override = headers.get(E2E_OVERRIDE_HEADER);
@@ -39,6 +46,13 @@ export const resolveMaintenanceWindowActive = (
 
   if (!isMaintenanceWindowEnabled()) {
     return false;
+  }
+
+  if (ratingTimestamps) {
+    return isRatingRecalculationPending(
+      ratingTimestamps.now,
+      ratingTimestamps.latestRatingCreated
+    );
   }
 
   return isWithinMaintenanceWindow(new Date());

--- a/apps/web/lib/orpc/schema/filtering.ts
+++ b/apps/web/lib/orpc/schema/filtering.ts
@@ -34,6 +34,8 @@ export type PlayerFilteringResult = z.infer<typeof PlayerFilteringResultSchema>;
 
 export const FilteringResultSchema = z.object({
   filterReportId: z.number().int().nonnegative(),
+  /** Server-side creation timestamp of the stored filter report. */
+  created: z.string(),
   playersPassed: z.number().int().nonnegative(),
   playersFailed: z.number().int().nonnegative(),
   filteringResults: z.array(PlayerFilteringResultSchema),

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    // Serializing declaration signatures for `.next/types` into `.tsbuildinfo` is
+    // slower than a plain full check (~35s vs ~12s), so the incremental cache is
+    // disabled here; the root tsconfig stays incremental for CI's typecheck job.
+    "incremental": false,
     "paths": {
       "@/*": ["./*"],
       "@otr/core": ["../../packages/otr-core/src/index.ts"],

--- a/packages/otr-core/src/maintenance/__tests__/window.test.ts
+++ b/packages/otr-core/src/maintenance/__tests__/window.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
-import { isWithinMaintenanceWindow } from '../window';
+import {
+  isRatingRecalculationPending,
+  isWithinMaintenanceWindow,
+  latestMaintenanceWindowStart,
+} from '../window';
 
 const at = (hours: number, minutes: number): Date =>
   new Date(Date.UTC(2026, 0, 6, hours, minutes, 0, 0));
@@ -44,5 +48,99 @@ describe('isWithinMaintenanceWindow', () => {
     expect(isWithinMaintenanceWindow(new Date('2026-01-06T13:50:00Z'))).toBe(
       false
     );
+  });
+});
+
+describe('latestMaintenanceWindowStart', () => {
+  it('returns the same-day start during the window (Tuesday 12:00 UTC)', () => {
+    expect(
+      latestMaintenanceWindowStart(new Date('2026-01-06T12:00:00Z'))
+    ).toEqual(new Date('2026-01-06T11:45:00Z'));
+  });
+
+  it('returns the same instant exactly at the window start', () => {
+    expect(
+      latestMaintenanceWindowStart(new Date('2026-01-06T11:45:00Z'))
+    ).toEqual(new Date('2026-01-06T11:45:00Z'));
+  });
+
+  it('returns the previous week just before the window opens (Tuesday 11:44 UTC)', () => {
+    expect(
+      latestMaintenanceWindowStart(new Date('2026-01-06T11:44:59Z'))
+    ).toEqual(new Date('2025-12-30T11:45:00Z'));
+  });
+
+  it('returns the prior Tuesday on a Wednesday', () => {
+    expect(
+      latestMaintenanceWindowStart(new Date('2026-01-07T09:00:00Z'))
+    ).toEqual(new Date('2026-01-06T11:45:00Z'));
+  });
+
+  it('returns the prior Tuesday on a Monday', () => {
+    expect(
+      latestMaintenanceWindowStart(new Date('2026-01-12T23:59:00Z'))
+    ).toEqual(new Date('2026-01-06T11:45:00Z'));
+  });
+});
+
+describe('isRatingRecalculationPending', () => {
+  it('returns false when no ratings exist', () => {
+    expect(
+      isRatingRecalculationPending(new Date('2026-01-06T12:00:00Z'), null)
+    ).toBe(false);
+  });
+
+  it('returns true inside the window before the processor commits', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-06T11:50:00Z'),
+        new Date('2026-01-05T12:00:00Z')
+      )
+    ).toBe(true);
+  });
+
+  it('returns false inside the window once the processor has committed', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-06T12:06:00Z'),
+        new Date('2026-01-06T12:05:00Z')
+      )
+    ).toBe(false);
+  });
+
+  it('returns true after the window ends when the processor overran', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-06T13:00:00Z'),
+        new Date('2025-12-30T12:04:00Z')
+      )
+    ).toBe(true);
+  });
+
+  it('returns true the next day when the processor never ran', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-07T08:00:00Z'),
+        new Date('2025-12-30T12:04:00Z')
+      )
+    ).toBe(true);
+  });
+
+  it('returns false later in the week after a normal run', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-09T18:00:00Z'),
+        new Date('2026-01-06T12:04:00Z')
+      )
+    ).toBe(false);
+  });
+
+  it('treats a rebuild exactly at the window start as fresh', () => {
+    expect(
+      isRatingRecalculationPending(
+        new Date('2026-01-06T12:00:00Z'),
+        new Date('2026-01-06T11:45:00Z')
+      )
+    ).toBe(false);
   });
 });

--- a/packages/otr-core/src/maintenance/window.ts
+++ b/packages/otr-core/src/maintenance/window.ts
@@ -39,3 +39,44 @@ export function isWithinMaintenanceWindow(now: Date): boolean {
     minutesUtc < MAINTENANCE_WINDOW_END_UTC_MINUTES
   );
 }
+
+/**
+ * Returns the start of the most recent maintenance window at or before the
+ * supplied instant (the moment the public replica is snapshotted).
+ */
+export function latestMaintenanceWindowStart(now: Date): Date {
+  const start = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() -
+        ((now.getUTCDay() - MAINTENANCE_WINDOW_UTC_DAY + 7) % 7),
+      Math.floor(MAINTENANCE_WINDOW_START_UTC_MINUTES / 60),
+      MAINTENANCE_WINDOW_START_UTC_MINUTES % 60
+    )
+  );
+
+  if (start.getTime() > now.getTime()) {
+    start.setUTCDate(start.getUTCDate() - 7);
+  }
+
+  return start;
+}
+
+/**
+ * Returns whether live ratings are stale relative to the most recent replica
+ * snapshot, i.e. the processor has not rebuilt `player_ratings` since the
+ * window start. `null` means no ratings exist, so nothing can be stale.
+ */
+export function isRatingRecalculationPending(
+  now: Date,
+  latestRatingCreated: Date | null
+): boolean {
+  if (!latestRatingCreated) {
+    return false;
+  }
+
+  return (
+    latestRatingCreated.getTime() < latestMaintenanceWindowStart(now).getTime()
+  );
+}


### PR DESCRIPTION
- Disables the filtering tool during the weekly rating generation maintenance window.
- The maintenace window re-enables once a new output from the processor is detected, rather than opening after 30 minutes. This ensures we do not put data verification in jeopardy should the processor fail to run for some reason.
- Fixes an issue with running end-to-end tests locally