### PR TITLE
feat: request tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,15 @@ DISCORD_WEBHOOK_URL=
 METRICS_PORT=9091
 METRICS_AUTH_TOKEN=secret
 
+## Tracing
+# Tracing is off until an OTLP endpoint is set. Docker sets this for the web and
+# data-worker containers; uncomment to export from a locally running app into
+# the compose stack's collector.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Fraction of traces to keep. Defaults to all of them.
+# OTEL_TRACES_SAMPLER=parentbased_traceidratio
+# OTEL_TRACES_SAMPLER_ARG=0.1
+
 ## Port overrides
 # Defaults --> (prod: web 3000 / grafana 3001, staging: web 3100 / grafana 3101).
 # WEB_PORT=3020

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,18 @@ Run commands from the repository root unless noted.
 - Prefer running the site and screenshotting it to check your own work before
   reporting a finished result.
 
+## Tracing
+
+- Spans go to Alloy over OTLP, then to Tempo; read them in Grafana under
+  Drilldown > Traces. Nothing is exported unless
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so local runs and tests stay quiet.
+- `@otr/core/tracing` owns the setup. A procedure span wraps every oRPC call and
+  each statement drizzle issues becomes a child span, so a slow query is visible
+  under the procedure that ran it. Queue messages carry the trace across to the
+  data worker.
+- Logs carry `traceId`, which is how Grafana links a log line to its trace.
+  Never put query parameters or user input on a span.
+
 ## Typography
 
 - Use the UI sans font (`--font-sans`, Inter) for all user-facing text, including

--- a/apps/data-worker/src/db/index.ts
+++ b/apps/data-worker/src/db/index.ts
@@ -1,5 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
 import { dbSchema } from '@otr/core/db';
+import { instrumentPgPool } from '@otr/core/tracing';
 
 import { loadRootEnv } from '../../../../lib/env/load-root-env';
 
@@ -11,8 +13,9 @@ if (!databaseUrl) {
   throw new Error('DATABASE_URL is not configured');
 }
 
-export const db = drizzle(databaseUrl, {
-  schema: dbSchema,
-});
+export const db = drizzle(
+  instrumentPgPool(new Pool({ connectionString: databaseUrl })),
+  { schema: dbSchema }
+);
 
 export type DatabaseClient = typeof db;

--- a/apps/data-worker/src/index.ts
+++ b/apps/data-worker/src/index.ts
@@ -1,3 +1,6 @@
+// Must be first so the tracer provider is live before anything else loads.
+import './tracing';
+
 import {
   QueueConstants,
   type FetchOsuMessage,

--- a/apps/data-worker/src/queue/rabbitmq-consumer.ts
+++ b/apps/data-worker/src/queue/rabbitmq-consumer.ts
@@ -1,4 +1,5 @@
 import { type MessageEnvelope, QueuePriorityArguments } from '@otr/core';
+import { traceConsume } from '@otr/core/tracing';
 import { connect, type ConsumeMessage } from 'amqplib';
 import { consoleLogger, type Logger } from '../logging/logger';
 import {
@@ -126,7 +127,9 @@ export class RabbitMqConsumer<TPayload> implements QueueConsumer<TPayload> {
     const startTime = Date.now();
 
     try {
-      await handler(queueMessage);
+      await traceConsume(this.options.queue, message.properties.headers, () =>
+        handler(queueMessage)
+      );
       queueMessagesProcessed.labels({ ...labels, status: 'success' }).inc();
     } catch (error) {
       this.logger.error('Queue handler threw an error', { error });

--- a/apps/data-worker/src/tracing.ts
+++ b/apps/data-worker/src/tracing.ts
@@ -1,0 +1,9 @@
+import { instrumentFetch, startTracing } from '@otr/core/tracing';
+
+import { loadRootEnv } from '../../../lib/env/load-root-env';
+
+loadRootEnv();
+
+if (startTracing({ serviceName: 'otr-data-worker' })) {
+  instrumentFetch();
+}

--- a/apps/web/app/server/oRPC/procedures/base.ts
+++ b/apps/web/app/server/oRPC/procedures/base.ts
@@ -7,6 +7,8 @@ import {
   generateCorrelationId,
   extractCorrelationId,
 } from '@otr/core/logging';
+import { setActiveSpanAttributes, withSpan } from '@otr/core/tracing';
+import { SpanKind } from '@opentelemetry/api';
 
 import { auth } from '@/lib/auth/auth';
 import { db } from '@/lib/db';
@@ -548,12 +550,34 @@ const extractRequestPath = (requestUrl?: string): string | null => {
   }
 };
 
+// Runs ahead of the rest of the chain so session lookups and database work all
+// land inside the procedure span.
+const withTracing = base.middleware(async ({ path, next }) => {
+  const procedurePath = formatProcedurePath(path);
+
+  return withSpan(
+    procedurePath,
+    {
+      kind: SpanKind.SERVER,
+      attributes: { 'rpc.system': 'orpc', 'rpc.method': procedurePath },
+    },
+    async () => next()
+  );
+});
+
 const withLoggingContext = base.middleware(async ({ context, path, next }) => {
   const correlationId =
     extractCorrelationId(context.headers) ?? generateCorrelationId();
   const procedurePath = formatProcedurePath(path);
   const actor = resolveActor(context);
   const requestPath = extractRequestPath(context.requestUrl);
+
+  setActiveSpanAttributes({
+    'otr.correlation_id': correlationId,
+    'otr.access_method': actor.accessMethod,
+    'otr.player_id': actor.playerId ?? undefined,
+    'otr.request_path': requestPath ?? undefined,
+  });
 
   const logger = rootLogger.child({
     correlationId,
@@ -691,6 +715,7 @@ const withErrorBoundary = base.middleware(async ({ path, next }) => {
 });
 
 export const publicProcedure = base
+  .use(withTracing)
   .use(withDatabase)
   .use(withOptionalApiKey)
   .use(withOptionalSession)
@@ -700,6 +725,7 @@ export const publicProcedure = base
   .use(withErrorBoundary);
 
 export const protectedProcedure = base
+  .use(withTracing)
   .use(withDatabase)
   .use(withAuth)
   .use(withLoggingContext)

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { startTracing } = await import('@otr/core/tracing');
+    startTracing({ serviceName: 'otr-web' });
+  }
+}

--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -1,15 +1,19 @@
 import { dbSchema } from '@otr/core/db';
+import { instrumentPgPool } from '@otr/core/tracing';
 import { createRequire } from 'node:module';
 
 type DrizzleModule = typeof import('drizzle-orm/node-postgres');
+type PgModule = typeof import('pg');
 
 const require = createRequire(import.meta.url);
 const { drizzle } = require('drizzle-orm/node-postgres') as DrizzleModule;
+const { Pool } = require('pg') as PgModule;
 
 const databaseUrl = process.env.DATABASE_URL;
 
-export const db = drizzle(databaseUrl, {
-  schema: dbSchema,
-});
+export const db = drizzle(
+  instrumentPgPool(new Pool({ connectionString: databaseUrl })),
+  { schema: dbSchema }
+);
 
 export type DatabaseClient = typeof db;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@alduino/humanizer": "^1.1.0",
     "@better-auth/api-key": "^1.6.12",
     "@hookform/resolvers": "^5.4.0",
+    "@opentelemetry/api": "^1.9.1",
     "@orpc/client": "^1.14.4",
     "@orpc/openapi": "^1.14.4",
     "@orpc/server": "^1.14.4",

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@alduino/humanizer": "^1.1.0",
         "@better-auth/api-key": "^1.6.12",
         "@hookform/resolvers": "^5.4.0",
+        "@opentelemetry/api": "^1.9.1",
         "@orpc/client": "^1.14.4",
         "@orpc/openapi": "^1.14.4",
         "@orpc/server": "^1.14.4",
@@ -179,6 +180,13 @@
       "name": "@otr/core",
       "version": "0.0.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.10.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/sdk-trace-node": "^2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "pino": "^10.3.1",
       },
       "peerDependencies": {
@@ -599,9 +607,33 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, ""],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.221.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.10.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.10.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.221.0", "", { "dependencies": { "@opentelemetry/otlp-exporter-base": "0.221.0", "@opentelemetry/otlp-transformer": "0.221.0", "@opentelemetry/sdk-trace": "2.10.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.221.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/otlp-transformer": "0.221.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.221.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.221.0", "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-logs": "0.221.0", "@opentelemetry/sdk-metrics": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.221.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.221.0", "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.10.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.10.0", "@opentelemetry/core": "2.10.0", "@opentelemetry/sdk-trace-base": "2.10.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@orpc/client": ["@orpc/client@1.14.4", "", { "dependencies": { "@orpc/shared": "1.14.4", "@orpc/standard-server": "1.14.4", "@orpc/standard-server-fetch": "1.14.4", "@orpc/standard-server-peer": "1.14.4" } }, "sha512-i6Z9FikIm9Qz3Br10vk8/cllgjdYdlRKK2OV3x2/CdOBRr+B68tboNdpH3eeb1kv8/Zd6ZsXcWaDfrANdj2GZQ=="],
 
@@ -1823,6 +1855,8 @@
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, ""],
 
+    "@better-auth/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@better-auth/core/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
@@ -1924,6 +1958,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "ofetch/ufo": ["ufo@1.6.1", "", {}, ""],
+
+    "prom-client/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -82,6 +82,8 @@ services:
       DATABASE_URL: ${DOCKER_DATABASE_URL}
       RABBITMQ_AMQP_URL: ${DOCKER_RABBITMQ_AMQP_URL}
       METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otr-staging-alloy:4318
+      OTEL_SERVICE_NAME: otr-web
     healthcheck:
       test:
         [
@@ -111,6 +113,8 @@ services:
       DATABASE_URL: ${DOCKER_DATABASE_URL}
       RABBITMQ_AMQP_URL: ${DOCKER_RABBITMQ_AMQP_URL}
       METRICS_PORT: '9091'
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otr-staging-alloy:4318
+      OTEL_SERVICE_NAME: otr-data-worker
     healthcheck:
       test:
         [
@@ -136,7 +140,10 @@ services:
           --config.file=/etc/prometheus/prometheus.yml \
           --storage.tsdb.path=/prometheus \
           --storage.tsdb.retention.time=30d \
-          --web.enable-lifecycle
+          --web.enable-lifecycle \
+          --web.enable-remote-write-receiver \
+          --enable-feature=exemplar-storage \
+          --enable-feature=native-histograms
     environment:
       METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN:-}
     volumes:
@@ -156,10 +163,25 @@ services:
       - loki-data:/loki
       - ./monitoring/staging/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
 
+  tempo:
+    image: grafana/tempo:3.0.3
+    container_name: otr-staging-tempo
+    restart: unless-stopped
+    command: ['-target=all', '-config.file=/etc/tempo/tempo.yaml']
+    volumes:
+      - ./monitoring/staging/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    depends_on:
+      - prometheus
+
   alloy:
     image: grafana/alloy:v1.17.1
     container_name: otr-staging-alloy
     restart: unless-stopped
+    ports:
+      # Loopback only so traces from a locally running app can reach the collector
+      - '127.0.0.1:4417:4317'
+      - '127.0.0.1:4418:4318'
     command:
       - run
       - '--storage.path=/var/lib/alloy/data'
@@ -170,6 +192,8 @@ services:
       - alloy-data:/var/lib/alloy/data
     depends_on:
       loki:
+        condition: service_started
+      tempo:
         condition: service_started
 
   grafana:
@@ -191,6 +215,7 @@ services:
     depends_on:
       - prometheus
       - loki
+      - tempo
 
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:v0.20.1
@@ -211,3 +236,4 @@ volumes:
   grafana-data:
   alloy-data:
   loki-data:
+  tempo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,8 @@ services:
       DATABASE_URL: ${DOCKER_DATABASE_URL}
       RABBITMQ_AMQP_URL: ${DOCKER_RABBITMQ_AMQP_URL}
       METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otr-alloy:4318
+      OTEL_SERVICE_NAME: otr-web
     deploy:
       resources:
         limits:
@@ -139,6 +141,8 @@ services:
       DATABASE_URL: ${DOCKER_DATABASE_URL}
       RABBITMQ_AMQP_URL: ${DOCKER_RABBITMQ_AMQP_URL}
       METRICS_PORT: '9091'
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otr-alloy:4318
+      OTEL_SERVICE_NAME: otr-data-worker
     healthcheck:
       test:
         [
@@ -164,7 +168,10 @@ services:
           --config.file=/etc/prometheus/prometheus.yml \
           --storage.tsdb.path=/prometheus \
           --storage.tsdb.retention.time=30d \
-          --web.enable-lifecycle
+          --web.enable-lifecycle \
+          --web.enable-remote-write-receiver \
+          --enable-feature=exemplar-storage \
+          --enable-feature=native-histograms
     environment:
       METRICS_AUTH_TOKEN: ${METRICS_AUTH_TOKEN:-}
     volumes:
@@ -184,10 +191,25 @@ services:
       - loki-data:/loki
       - ./monitoring/prod/loki/loki-config.yaml:/etc/loki/loki-config.yaml:ro
 
+  tempo:
+    image: grafana/tempo:3.0.3
+    container_name: otr-tempo
+    restart: unless-stopped
+    command: ['-target=all', '-config.file=/etc/tempo/tempo.yaml']
+    volumes:
+      - ./monitoring/prod/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo-data:/var/tempo
+    depends_on:
+      - prometheus
+
   alloy:
     image: grafana/alloy:v1.17.1
     container_name: otr-alloy
     restart: unless-stopped
+    ports:
+      # Loopback only so traces from a locally running app can reach the collector
+      - '127.0.0.1:4317:4317'
+      - '127.0.0.1:4318:4318'
     command:
       - run
       - '--storage.path=/var/lib/alloy/data'
@@ -198,6 +220,8 @@ services:
       - alloy-data:/var/lib/alloy/data
     depends_on:
       loki:
+        condition: service_started
+      tempo:
         condition: service_started
 
   grafana:
@@ -219,6 +243,7 @@ services:
     depends_on:
       - prometheus
       - loki
+      - tempo
 
   postgres-exporter:
     image: prometheuscommunity/postgres-exporter:v0.20.1
@@ -253,3 +278,4 @@ volumes:
   grafana-data:
   alloy-data:
   loki-data:
+  tempo-data:

--- a/monitoring/prod/alloy/config.alloy
+++ b/monitoring/prod/alloy/config.alloy
@@ -42,3 +42,33 @@ loki.write "default" {
 		url = "http://otr-loki:3100/loki/api/v1/push"
 	}
 }
+
+otelcol.receiver.otlp "otlp" {
+	grpc {
+		endpoint = "0.0.0.0:4317"
+	}
+
+	http {
+		endpoint = "0.0.0.0:4318"
+	}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
+	}
+}
+
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "otr-tempo:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/monitoring/prod/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/prod/grafana/provisioning/datasources/datasources.yml
@@ -2,15 +2,63 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://otr-prometheus:9090
     isDefault: true
     editable: false
+    jsonData:
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://otr-loki:3100
     editable: false
     jsonData:
       maxLines: 1000
+      derivedFields:
+        - name: traceId
+          matcherType: regex
+          matcherRegex: 'traceId=([a-f0-9]{32})'
+          url: '$${__value.raw}'
+          datasourceUid: tempo
+          urlDisplayLabel: 'View trace'
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://otr-tempo:3200
+    editable: false
+    jsonData:
+      streamingEnabled:
+        search: true
+        metrics: true
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: '-5m'
+        spanEndTimeShift: '5m'
+        filterByTraceID: true
+        tags:
+          - key: service.name
+            value: service
+      tracesToMetrics:
+        datasourceUid: prometheus
+        spanStartTimeShift: '-5m'
+        spanEndTimeShift: '5m'
+        tags:
+          - key: service.name
+            value: service
+        queries:
+          - name: 'Request rate'
+            query: 'sum(rate(traces_spanmetrics_calls_total{$$__tags}[$$__rate_interval]))'
+          - name: 'Error rate'
+            query: 'sum(rate(traces_spanmetrics_calls_total{$$__tags,status_code="STATUS_CODE_ERROR"}[$$__rate_interval]))'

--- a/monitoring/prod/prometheus/prometheus.yml
+++ b/monitoring/prod/prometheus/prometheus.yml
@@ -33,3 +33,7 @@ scrape_configs:
   - job_name: 'data-worker'
     static_configs:
       - targets: ['otr-data-worker:9091']
+
+  - job_name: 'tempo'
+    static_configs:
+      - targets: ['otr-tempo:3200']

--- a/monitoring/prod/tempo/tempo.yaml
+++ b/monitoring/prod/tempo/tempo.yaml
@@ -1,0 +1,43 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: '0.0.0.0:4317'
+        http:
+          endpoint: '0.0.0.0:4318'
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://otr-prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    compaction:
+      block_retention: 336h
+    metrics_generator:
+      processors: ['span-metrics', 'service-graphs']
+      generate_native_histograms: both
+
+usage_report:
+  reporting_enabled: false

--- a/monitoring/staging/alloy/config.alloy
+++ b/monitoring/staging/alloy/config.alloy
@@ -42,3 +42,33 @@ loki.write "default" {
 		url = "http://otr-staging-loki:3100/loki/api/v1/push"
 	}
 }
+
+otelcol.receiver.otlp "otlp" {
+	grpc {
+		endpoint = "0.0.0.0:4317"
+	}
+
+	http {
+		endpoint = "0.0.0.0:4318"
+	}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
+	}
+}
+
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "otr-staging-tempo:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/monitoring/staging/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/staging/grafana/provisioning/datasources/datasources.yml
@@ -2,15 +2,63 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://otr-staging-prometheus:9090
     isDefault: true
     editable: false
+    jsonData:
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo
 
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://otr-staging-loki:3100
     editable: false
     jsonData:
       maxLines: 1000
+      derivedFields:
+        - name: traceId
+          matcherType: regex
+          matcherRegex: 'traceId=([a-f0-9]{32})'
+          url: '$${__value.raw}'
+          datasourceUid: tempo
+          urlDisplayLabel: 'View trace'
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://otr-staging-tempo:3200
+    editable: false
+    jsonData:
+      streamingEnabled:
+        search: true
+        metrics: true
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: '-5m'
+        spanEndTimeShift: '5m'
+        filterByTraceID: true
+        tags:
+          - key: service.name
+            value: service
+      tracesToMetrics:
+        datasourceUid: prometheus
+        spanStartTimeShift: '-5m'
+        spanEndTimeShift: '5m'
+        tags:
+          - key: service.name
+            value: service
+        queries:
+          - name: 'Request rate'
+            query: 'sum(rate(traces_spanmetrics_calls_total{$$__tags}[$$__rate_interval]))'
+          - name: 'Error rate'
+            query: 'sum(rate(traces_spanmetrics_calls_total{$$__tags,status_code="STATUS_CODE_ERROR"}[$$__rate_interval]))'

--- a/monitoring/staging/prometheus/prometheus.yml
+++ b/monitoring/staging/prometheus/prometheus.yml
@@ -29,3 +29,7 @@ scrape_configs:
   - job_name: 'data-worker'
     static_configs:
       - targets: ['otr-staging-data-worker:9091']
+
+  - job_name: 'tempo'
+    static_configs:
+      - targets: ['otr-staging-tempo:3200']

--- a/monitoring/staging/tempo/tempo.yaml
+++ b/monitoring/staging/tempo/tempo.yaml
@@ -1,0 +1,43 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: '0.0.0.0:4317'
+        http:
+          endpoint: '0.0.0.0:4318'
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://otr-staging-prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    compaction:
+      block_retention: 336h
+    metrics_generator:
+      processors: ['span-metrics', 'service-graphs']
+      generate_native_histograms: both
+
+usage_report:
+  reporting_enabled: false

--- a/packages/otr-core/package.json
+++ b/packages/otr-core/package.json
@@ -16,12 +16,21 @@
     "./queues/*": "./src/queues/*",
     "./messages/*": "./src/messages/*",
     "./logging": "./src/logging/index.ts",
-    "./logging/*": "./src/logging/*"
+    "./logging/*": "./src/logging/*",
+    "./tracing": "./src/tracing/index.ts",
+    "./tracing/*": "./src/tracing/*"
   },
   "peerDependencies": {
     "drizzle-orm": "^0.45.2"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/core": "^2.10.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+    "@opentelemetry/resources": "^2.10.0",
+    "@opentelemetry/sdk-trace-base": "^2.10.0",
+    "@opentelemetry/sdk-trace-node": "^2.10.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "pino": "^10.3.1"
   }
 }

--- a/packages/otr-core/src/logging/logger.ts
+++ b/packages/otr-core/src/logging/logger.ts
@@ -1,4 +1,5 @@
 import pino from 'pino';
+import { trace } from '@opentelemetry/api';
 import type { Logger, LogContext, LogLevel } from './types';
 
 const IGNORED_KEYS = new Set(['level', 'time', 'msg', 'pid', 'hostname']);
@@ -96,6 +97,17 @@ const keyValueDestination = (): pino.DestinationStream => ({
   },
 });
 
+// Grafana links logs to traces off these fields; keep the names in step with
+// the Loki datasource's derived fields.
+const traceBindings = () => {
+  const span = trace.getActiveSpan()?.spanContext();
+  if (!span || !trace.isSpanContextValid(span)) {
+    return {};
+  }
+
+  return { traceId: span.traceId, spanId: span.spanId };
+};
+
 function createPinoLogger(serviceName: string): pino.Logger {
   const level = (process.env.LOG_LEVEL as LogLevel) ?? 'info';
 
@@ -103,6 +115,7 @@ function createPinoLogger(serviceName: string): pino.Logger {
     {
       level,
       base: { service: serviceName },
+      mixin: traceBindings,
       timestamp: pino.stdTimeFunctions.isoTime,
       serializers: {
         error: (err: unknown) => {

--- a/packages/otr-core/src/queues/rabbitmq-publisher.ts
+++ b/packages/otr-core/src/queues/rabbitmq-publisher.ts
@@ -1,6 +1,7 @@
 import { connect, type Options } from 'amqplib';
 import type { MessageEnvelope } from '@otr/core';
 import { QueuePriorityArguments, createMessageMetadata } from '@otr/core';
+import { injectTraceHeaders, tracePublish } from '../tracing';
 
 import type {
   QueueMessagePayload,
@@ -44,27 +45,30 @@ export class RabbitMqPublisher<
     payload: QueueMessagePayload<TMessage>,
     options: QueuePublishOptions = {}
   ): Promise<TMessage> {
-    const channel = await this.ensureChannel();
-    const metadata = createMessageMetadata(options.metadata);
-    const message = { ...metadata, ...(payload ?? {}) } as TMessage;
+    return tracePublish(this.queue, async () => {
+      const channel = await this.ensureChannel();
+      const metadata = createMessageMetadata(options.metadata);
+      const message = { ...metadata, ...(payload ?? {}) } as TMessage;
 
-    const publishOptions: Options.Publish = {
-      persistent: true,
-      ...this.basePublishOptions,
-    };
+      const publishOptions: Options.Publish = {
+        persistent: true,
+        ...this.basePublishOptions,
+        headers: injectTraceHeaders({ ...this.basePublishOptions?.headers }),
+      };
 
-    if (publishOptions.priority === undefined) {
-      publishOptions.priority = metadata.priority;
-    }
+      if (publishOptions.priority === undefined) {
+        publishOptions.priority = metadata.priority;
+      }
 
-    channel.sendToQueue(
-      this.queue,
-      Buffer.from(JSON.stringify(message), 'utf-8'),
-      publishOptions
-    );
+      channel.sendToQueue(
+        this.queue,
+        Buffer.from(JSON.stringify(message), 'utf-8'),
+        publishOptions
+      );
 
-    await channel.waitForConfirms();
-    return message;
+      await channel.waitForConfirms();
+      return message;
+    });
   }
 
   async close(): Promise<void> {

--- a/packages/otr-core/src/tracing/database.ts
+++ b/packages/otr-core/src/tracing/database.ts
@@ -1,0 +1,134 @@
+import { SpanKind } from '@opentelemetry/api';
+import {
+  ATTR_DB_COLLECTION_NAME,
+  ATTR_DB_NAMESPACE,
+  ATTR_DB_OPERATION_NAME,
+  ATTR_DB_QUERY_TEXT,
+  ATTR_DB_SYSTEM_NAME,
+  DB_SYSTEM_NAME_VALUE_POSTGRESQL,
+} from '@opentelemetry/semantic-conventions';
+
+import { withSpan } from './tracer';
+
+// Still incubating in @opentelemetry/semantic-conventions
+const ATTR_DB_RESPONSE_RETURNED_ROWS = 'db.response.returned_rows';
+
+type QueryInput = string | { text?: string } | undefined;
+
+interface PgQueryable {
+  query(...args: never[]): unknown;
+}
+
+interface PgPoolLike extends PgQueryable {
+  connect(...args: never[]): unknown;
+  options?: { database?: string };
+}
+
+const INSTRUMENTED = Symbol.for('otr.tracing.pg');
+
+const OPERATION_PATTERN = /^\s*(\w+)/;
+const TABLE_PATTERN = /\b(?:from|into|update|join)\s+"?([\w.]+)"?/i;
+
+const readSql = (input: QueryInput): string => {
+  if (typeof input === 'string') return input;
+  return input?.text ?? '';
+};
+
+const describeQuery = (sql: string) => {
+  const operation = OPERATION_PATTERN.exec(sql)?.[1]?.toUpperCase();
+  const collection = TABLE_PATTERN.exec(sql)?.[1];
+
+  return {
+    operation,
+    collection,
+    name: [operation ?? 'query', collection].filter(Boolean).join(' '),
+  };
+};
+
+const isPromise = (value: unknown): value is Promise<unknown> =>
+  typeof (value as Promise<unknown>)?.then === 'function';
+
+const rowCountOf = (result: unknown): number | undefined => {
+  const count = (result as { rowCount?: unknown } | null)?.rowCount;
+  return typeof count === 'number' ? count : undefined;
+};
+
+function traceQueries<T extends PgQueryable>(target: T, database?: string): T {
+  const marked = target as T & { [INSTRUMENTED]?: boolean };
+  if (marked[INSTRUMENTED]) {
+    return target;
+  }
+  marked[INSTRUMENTED] = true;
+
+  const original = target.query.bind(target) as (...args: unknown[]) => unknown;
+
+  const traced = (...args: unknown[]) => {
+    const sql = readSql(args[0] as QueryInput);
+
+    // Callback-style calls can't be awaited; pass them straight through.
+    if (!sql || typeof args[args.length - 1] === 'function') {
+      return original(...args);
+    }
+
+    const { operation, collection, name } = describeQuery(sql);
+
+    return withSpan(
+      name,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_POSTGRESQL,
+          [ATTR_DB_NAMESPACE]: database,
+          [ATTR_DB_QUERY_TEXT]: sql,
+          [ATTR_DB_OPERATION_NAME]: operation,
+          [ATTR_DB_COLLECTION_NAME]: collection,
+        },
+      },
+      async (span) => {
+        const result = await (original(...args) as Promise<unknown>);
+        const rows = rowCountOf(result);
+        if (rows !== undefined) {
+          span.setAttribute(ATTR_DB_RESPONSE_RETURNED_ROWS, rows);
+        }
+        return result;
+      }
+    );
+  };
+
+  Object.defineProperty(target, 'query', { value: traced, writable: true });
+  return target;
+}
+
+/**
+ * Wraps a `pg.Pool` so every statement drizzle issues becomes a child span of
+ * whatever is active — an oRPC procedure, a queue handler, a render. Query
+ * parameters are deliberately left off the span; only SQL text and row count
+ * are recorded.
+ */
+export function instrumentPgPool<T extends PgPoolLike>(pool: T): T {
+  const database = pool.options?.database;
+  const connect = pool.connect.bind(pool) as (...args: unknown[]) => unknown;
+
+  if ((pool as { [INSTRUMENTED]?: boolean })[INSTRUMENTED]) {
+    return pool;
+  }
+
+  traceQueries(pool, database);
+
+  // Transactions run on a checked-out client, which bypasses `pool.query`.
+  Object.defineProperty(pool, 'connect', {
+    writable: true,
+    value: (...args: unknown[]) => {
+      const result = connect(...args);
+      if (!isPromise(result)) {
+        return result;
+      }
+
+      return result.then((client) =>
+        client ? traceQueries(client as PgQueryable, database) : client
+      );
+    },
+  });
+
+  return pool;
+}

--- a/packages/otr-core/src/tracing/http.ts
+++ b/packages/otr-core/src/tracing/http.ts
@@ -1,0 +1,63 @@
+import { SpanKind } from '@opentelemetry/api';
+import {
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_URL_FULL,
+} from '@opentelemetry/semantic-conventions';
+
+import { withSpan } from './tracer';
+
+const INSTRUMENTED = Symbol.for('otr.tracing.fetch');
+
+const readRequest = (input: RequestInfo | URL, init?: RequestInit) => {
+  const request = input instanceof Request ? input : null;
+  const url = request ? request.url : String(input);
+  const method = (init?.method ?? request?.method ?? 'GET').toUpperCase();
+
+  return { url, method };
+};
+
+/**
+ * Gives outbound calls — the osu! and osu!track APIs — their own client spans.
+ * Next.js already traces its own fetches, so this is for the worker.
+ */
+export function instrumentFetch(): void {
+  const original = globalThis.fetch as typeof fetch & {
+    [INSTRUMENTED]?: boolean;
+  };
+
+  if (!original || original[INSTRUMENTED]) {
+    return;
+  }
+
+  const traced = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const { url, method } = readRequest(input, init);
+    let host: string | undefined;
+    try {
+      host = new URL(url).host;
+    } catch {
+      host = undefined;
+    }
+
+    return withSpan(
+      `${method} ${host ?? 'fetch'}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [ATTR_HTTP_REQUEST_METHOD]: method,
+          [ATTR_URL_FULL]: url,
+          [ATTR_SERVER_ADDRESS]: host,
+        },
+      },
+      async (span) => {
+        const response = await original(input, init);
+        span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+        return response;
+      }
+    );
+  };
+
+  Object.defineProperty(traced, INSTRUMENTED, { value: true });
+  globalThis.fetch = traced as typeof fetch;
+}

--- a/packages/otr-core/src/tracing/index.ts
+++ b/packages/otr-core/src/tracing/index.ts
@@ -1,0 +1,13 @@
+export { startTracing, shutdownTracing } from './provider';
+export type { StartTracingOptions } from './provider';
+export {
+  getTracer,
+  withSpan,
+  recordException,
+  setActiveSpanAttributes,
+  activeTraceId,
+} from './tracer';
+export { instrumentPgPool } from './database';
+export { instrumentFetch } from './http';
+export { injectTraceHeaders, tracePublish, traceConsume } from './messaging';
+export type { MessageHeaders } from './messaging';

--- a/packages/otr-core/src/tracing/messaging.ts
+++ b/packages/otr-core/src/tracing/messaging.ts
@@ -1,0 +1,76 @@
+import {
+  context,
+  propagation,
+  SpanKind,
+  type Attributes,
+} from '@opentelemetry/api';
+
+import { withSpan } from './tracer';
+
+const MESSAGING_SYSTEM = 'rabbitmq';
+
+export type MessageHeaders = Record<string, unknown>;
+
+const queueAttributes = (queue: string, extra?: Attributes): Attributes => ({
+  'messaging.system': MESSAGING_SYSTEM,
+  'messaging.destination.name': queue,
+  ...extra,
+});
+
+/** Serialises the active trace into AMQP headers so the consumer can continue it. */
+export function injectTraceHeaders(
+  headers: MessageHeaders = {}
+): MessageHeaders {
+  propagation.inject(context.active(), headers);
+  return headers;
+}
+
+export function tracePublish<T>(
+  queue: string,
+  run: () => Promise<T>
+): Promise<T> {
+  return withSpan(
+    `publish ${queue}`,
+    {
+      kind: SpanKind.PRODUCER,
+      attributes: queueAttributes(queue, {
+        'messaging.operation.name': 'publish',
+      }),
+    },
+    run
+  );
+}
+
+/**
+ * Continues the publisher's trace, so a queued job shows up under whatever
+ * enqueued it rather than as an unrelated root span.
+ */
+// amqplib hands back long strings as Buffers, which the propagator can't read.
+const asStrings = (headers: MessageHeaders): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, String(value)])
+  );
+
+export function traceConsume<T>(
+  queue: string,
+  headers: MessageHeaders | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  const parent = propagation.extract(
+    context.active(),
+    headers ? asStrings(headers) : {}
+  );
+
+  return context.with(parent, () =>
+    withSpan(
+      `process ${queue}`,
+      {
+        kind: SpanKind.CONSUMER,
+        attributes: queueAttributes(queue, {
+          'messaging.operation.name': 'process',
+        }),
+      },
+      run
+    )
+  );
+}

--- a/packages/otr-core/src/tracing/provider.ts
+++ b/packages/otr-core/src/tracing/provider.ts
@@ -1,0 +1,85 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import {
+  defaultResource,
+  resourceFromAttributes,
+} from '@opentelemetry/resources';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAME,
+} from '@opentelemetry/semantic-conventions';
+
+export interface StartTracingOptions {
+  /** Fallback when OTEL_SERVICE_NAME is unset. */
+  serviceName: string;
+}
+
+let provider: NodeTracerProvider | null = null;
+
+const resolveEnvironment = (): string => {
+  if (process.env.NEXT_PUBLIC_IS_STAGING === 'true') {
+    return 'staging';
+  }
+
+  return process.env.NODE_ENV === 'production' ? 'production' : 'development';
+};
+
+/**
+ * Registers the global tracer provider. Tracing stays off until
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set, so local runs and tests are unaffected.
+ */
+export function startTracing({
+  serviceName,
+}: StartTracingOptions): NodeTracerProvider | null {
+  if (provider) {
+    return provider;
+  }
+
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    return null;
+  }
+
+  if (process.env.OTEL_LOG_LEVEL === 'debug') {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  }
+
+  provider = new NodeTracerProvider({
+    resource: defaultResource().merge(
+      resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME ?? serviceName,
+        [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: resolveEnvironment(),
+      })
+    ),
+    spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
+  });
+
+  provider.register({
+    propagator: new CompositePropagator({
+      propagators: [
+        new W3CTraceContextPropagator(),
+        new W3CBaggagePropagator(),
+      ],
+    }),
+  });
+
+  const flush = () => {
+    void provider?.shutdown().catch(() => undefined);
+  };
+
+  process.once('SIGTERM', flush);
+  process.once('SIGINT', flush);
+
+  return provider;
+}
+
+export async function shutdownTracing(): Promise<void> {
+  await provider?.shutdown();
+  provider = null;
+}

--- a/packages/otr-core/src/tracing/tracer.ts
+++ b/packages/otr-core/src/tracing/tracer.ts
@@ -1,0 +1,50 @@
+import {
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Span,
+  type SpanOptions,
+  type Tracer,
+} from '@opentelemetry/api';
+
+export const getTracer = (name = 'otr'): Tracer => trace.getTracer(name);
+
+export function recordException(span: Span, error: unknown): void {
+  span.recordException(
+    error instanceof Error ? error : new Error(String(error))
+  );
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
+/** Runs `fn` inside a span, recording any thrown error before rethrowing. */
+export async function withSpan<T>(
+  name: string,
+  options: SpanOptions,
+  fn: (span: Span) => Promise<T>
+): Promise<T> {
+  return getTracer().startActiveSpan(name, options, async (span) => {
+    try {
+      return await fn(span);
+    } catch (error) {
+      recordException(span, error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/** Adds attributes to the span already in context, if any. */
+export function setActiveSpanAttributes(attributes: Attributes): void {
+  trace.getActiveSpan()?.setAttributes(attributes);
+}
+
+export function activeTraceId(): string | undefined {
+  const context = trace.getActiveSpan()?.spanContext();
+  return context && trace.isSpanContextValid(context)
+    ? context.traceId
+    : undefined;
+}


### PR DESCRIPTION
- Adds Tempo to the prod and staging stacks, fed by a new OTLP receiver in Alloy.
- Adds a Tempo datasource linked to Loki and Prometheus, plus the Prometheus flags span metrics need.
- Adds `@otr/core/tracing`: OpenTelemetry setup, an oRPC procedure span, and a `pg` pool wrapper that spans each drizzle statement.
- Passes trace context through RabbitMQ headers into the data worker.
- Adds `traceId` to pino logs.

Nothing exports unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set; compose sets it. Sampling keeps every trace, untuned for prod volume. `apps/web/instrumentation.ts` conflicts with the untracked copy on master.
