### PR TITLE
feat: per-PR preview deployments on private tailnet urls

### DIFF
--- a/.github/workflows/dev-tier.yml
+++ b/.github/workflows/dev-tier.yml
@@ -1,0 +1,123 @@
+name: Dev tier
+
+# The shared database and queue that PR previews read from. Deliberately kept
+# out of deploy.yml: this tier has no application images and no migrate
+# service, so it does not fit that workflow's build-and-migrate shape.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Operation to run'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - restore
+          - check
+  schedule:
+    # Nightly replica refresh, after the processor run at 12:00 UTC.
+    - cron: '0 14 * * *'
+
+concurrency:
+  group: dev-tier
+  cancel-in-progress: false
+
+jobs:
+  run:
+    name: ${{ github.event.inputs.action || 'restore' }}
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docker-compose-dev.yml
+            scripts/preview
+            apps/web/drizzle/meta
+
+      - name: Resolve expected migration count
+        id: migrations
+        run: |
+          set -euo pipefail
+          count=$(jq '.entries | length' apps/web/drizzle/meta/_journal.json)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Connect to tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: ${{ secrets.SSH_HOST }}
+
+      - name: Upload dev tier assets
+        if: ${{ (github.event.inputs.action || 'restore') == 'deploy' }}
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          DEV_REMOTE_PATH: ${{ secrets.DEV_REMOTE_PATH }}
+          ENV_CONTENT: ${{ secrets.DEV_ENV }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$ENV_CONTENT" > .env
+          cp docker-compose-dev.yml docker-compose.yml
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            mkdir -p "$DEV_REMOTE_PATH/scripts"
+          scp -o StrictHostKeyChecking=no -r .env docker-compose.yml \
+            "$SSH_USER@$SSH_HOST:$DEV_REMOTE_PATH/"
+          scp -o StrictHostKeyChecking=no -r scripts/preview \
+            "$SSH_USER@$SSH_HOST:$DEV_REMOTE_PATH/scripts/"
+
+      - name: Bring up dev tier
+        if: ${{ (github.event.inputs.action || 'restore') == 'deploy' }}
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          DEV_REMOTE_PATH: ${{ secrets.DEV_REMOTE_PATH }}
+        run: |
+          set -euo pipefail
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$DEV_REMOTE_PATH" <<'EOF'
+            set -euo pipefail
+            cd "$1"
+            chmod +x scripts/preview/dev-db.sh
+            docker compose pull
+            docker compose up -d --remove-orphans
+            # Nothing consumes these queues without a data worker, so let idle
+            # ones delete themselves after a day.
+            until docker exec otr-dev-rabbitmq rabbitmq-diagnostics -q ping; do sleep 3; done
+            docker exec otr-dev-rabbitmq rabbitmqctl set_policy preview-expiry \
+              '.*' '{"expires":86400000}' --apply-to queues
+          EOF
+
+      - name: Run database operation
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          DEV_REMOTE_PATH: ${{ secrets.DEV_REMOTE_PATH }}
+          OTR_SCRIPTS_DIR: ${{ secrets.OTR_SCRIPTS_DIR }}
+          ACTION: ${{ github.event.inputs.action || 'restore' }}
+          EXPECTED_MIGRATIONS: ${{ steps.migrations.outputs.count }}
+        run: |
+          set -euo pipefail
+          operation="$ACTION"
+          if [[ "$operation" == "deploy" ]]; then
+            operation="check"
+          fi
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$DEV_REMOTE_PATH" "$operation" "$OTR_SCRIPTS_DIR" "$EXPECTED_MIGRATIONS" <<'EOF'
+            set -euo pipefail
+            cd "$1"
+            export OTR_SCRIPTS_DIR="$3"
+            export EXPECTED_MIGRATIONS="$4"
+            # A first deploy has no database yet, so a failing check restores.
+            if [[ "$2" == "check" ]]; then
+              ./scripts/preview/dev-db.sh check || ./scripts/preview/dev-db.sh restore
+            else
+              ./scripts/preview/dev-db.sh "$2"
+            fi
+          EOF

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,229 @@
+name: PR preview
+
+# Publishes a labelled PR to a private tailnet URL. Runs the website only:
+# the database and queue come from the shared dev tier, and no data worker
+# means previews never call the osu! API.
+#
+# Uses `pull_request`, not `pull_request_target`, so forks get no secrets and
+# no preview. Previews run PR code on the deployment host, so they are limited
+# to branches in this repository.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    name: Deploy preview
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    environment: dev
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve preview context
+        id: context
+        env:
+          TS_TAILNET: ${{ vars.TS_TAILNET }}
+          DEV_LIVE_DB: ${{ vars.DEV_LIVE_DB || 'otr_dev' }}
+        run: |
+          set -euo pipefail
+          hostname="otr-pr-${PR_NUMBER}"
+          echo "hostname=$hostname" >> "$GITHUB_OUTPUT"
+          echo "url=https://${hostname}.${TS_TAILNET}" >> "$GITHUB_OUTPUT"
+          echo "project=otr-pr-${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          # The shared database tracks the base branch, so its expected
+          # migration count comes from there rather than from this PR.
+          base_count=$(git show "$BASE_SHA:apps/web/drizzle/meta/_journal.json" | jq '.entries | length')
+          echo "migrations=$base_count" >> "$GITHUB_OUTPUT"
+
+          # A PR that adds migrations gets its own database, so it never
+          # migrates the schema the other previews are sharing.
+          if git diff --name-only "$BASE_SHA" HEAD -- apps/web/drizzle | grep -q .; then
+            echo "database=otr_pr_${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "migration=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "database=${DEV_LIVE_DB}" >> "$GITHUB_OUTPUT"
+            echo "migration=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: stagecodes/otr-web:pr-${{ env.PR_NUMBER }}
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,scope=web-pr-${{ env.PR_NUMBER }},mode=max
+
+      - name: Connect to tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: ${{ secrets.SSH_HOST }}
+
+      - name: Verify dev database, restoring if unhealthy
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          DEV_REMOTE_PATH: ${{ secrets.DEV_REMOTE_PATH }}
+          OTR_SCRIPTS_DIR: ${{ secrets.OTR_SCRIPTS_DIR }}
+          EXPECTED_MIGRATIONS: ${{ steps.context.outputs.migrations }}
+          NEEDS_CLONE: ${{ steps.context.outputs.migration }}
+          PREVIEW_DB: ${{ steps.context.outputs.database }}
+        run: |
+          set -euo pipefail
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$DEV_REMOTE_PATH" "$OTR_SCRIPTS_DIR" "$EXPECTED_MIGRATIONS" "$NEEDS_CLONE" "$PREVIEW_DB" <<'EOF'
+            set -euo pipefail
+            cd "$1"
+            export OTR_SCRIPTS_DIR="$2"
+            export EXPECTED_MIGRATIONS="$3"
+            ./scripts/preview/dev-db.sh check || ./scripts/preview/dev-db.sh restore
+            if [[ "$4" == "true" ]]; then
+              ./scripts/preview/dev-db.sh clone "$5"
+            fi
+          EOF
+
+      - name: Upload preview assets
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          PREVIEW_REMOTE_PATH: ${{ secrets.PREVIEW_REMOTE_PATH }}
+          APP_ENV_CONTENT: ${{ secrets.PREVIEW_ENV }}
+          DB_URL_PREFIX: ${{ secrets.PREVIEW_DB_URL_PREFIX }}
+          PREVIEW_RABBITMQ_URL: ${{ secrets.PREVIEW_RABBITMQ_URL }}
+          TS_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_CLIENT_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          PREVIEW_URL: ${{ steps.context.outputs.url }}
+          PREVIEW_HOSTNAME: ${{ steps.context.outputs.hostname }}
+          PREVIEW_DB: ${{ steps.context.outputs.database }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$APP_ENV_CONTENT" > app.env
+          cat > .env <<ENVFILE
+          IMAGE_TAG=pr-${PR_NUMBER}
+          PREVIEW_URL=${PREVIEW_URL}
+          PREVIEW_HOSTNAME=${PREVIEW_HOSTNAME}
+          PREVIEW_DATABASE_URL=${DB_URL_PREFIX}${PREVIEW_DB}
+          PREVIEW_RABBITMQ_URL=${PREVIEW_RABBITMQ_URL}
+          TS_CLIENT_ID=${TS_CLIENT_ID}
+          TS_CLIENT_SECRET=${TS_CLIENT_SECRET}
+          ENVFILE
+          cp docker-compose-preview.yml docker-compose.yml
+          remote="$PREVIEW_REMOTE_PATH/pr-${PR_NUMBER}"
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" mkdir -p "$remote"
+          scp -o StrictHostKeyChecking=no -r \
+            .env app.env docker-compose.yml preview/ts-config \
+            "$SSH_USER@$SSH_HOST:$remote/"
+
+      - name: Start preview stack
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          PREVIEW_REMOTE_PATH: ${{ secrets.PREVIEW_REMOTE_PATH }}
+          PROJECT: ${{ steps.context.outputs.project }}
+          NEEDS_MIGRATE: ${{ steps.context.outputs.migration }}
+        run: |
+          set -euo pipefail
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$PREVIEW_REMOTE_PATH/pr-${PR_NUMBER}" "$PROJECT" "$NEEDS_MIGRATE" <<'EOF'
+            set -euo pipefail
+            cd "$1"
+            docker compose -p "$2" pull
+            if [[ "$3" == "true" ]]; then
+              docker compose -p "$2" --profile migrate run --rm migrate
+            fi
+            docker compose -p "$2" up -d --remove-orphans
+          EOF
+
+      - name: Comment preview URL
+        if: ${{ github.event.action != 'synchronize' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIEW_URL: ${{ steps.context.outputs.url }}
+          PREVIEW_DB: ${{ steps.context.outputs.database }}
+          IS_MIGRATION: ${{ steps.context.outputs.migration }}
+        run: |
+          set -euo pipefail
+          if [[ "$IS_MIGRATION" == "true" ]]; then
+            note="Migrations ran against a dedicated clone (\`${PREVIEW_DB}\`)."
+          else
+            note="Using the shared dev database (\`${PREVIEW_DB}\`)."
+          fi
+          body=$(printf 'Preview: %s\n\n%s Sign in with the test-auth endpoint; osu! login is not wired up on previews.' \
+            "$PREVIEW_URL" "$note")
+          gh pr comment "$PR_NUMBER" --body "$body"
+
+  teardown:
+    name: Tear down preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    environment: dev
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Connect to tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: ${{ secrets.SSH_HOST }}
+
+      - name: Remove preview stack and database
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          PREVIEW_REMOTE_PATH: ${{ secrets.PREVIEW_REMOTE_PATH }}
+          DEV_REMOTE_PATH: ${{ secrets.DEV_REMOTE_PATH }}
+        run: |
+          set -euo pipefail
+          ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            bash -s -- "$PREVIEW_REMOTE_PATH" "$DEV_REMOTE_PATH" "$PR_NUMBER" <<'EOF'
+            set -euo pipefail
+            directory="$1/pr-$3"
+            if [[ -d "$directory" ]]; then
+              cd "$directory"
+              docker compose -p "otr-pr-$3" down -v --remove-orphans
+              cd /
+              rm -rf "$directory"
+            fi
+            # The tailnet node is ephemeral and removes itself with the stack.
+            cd "$2"
+            ./scripts/preview/dev-db.sh drop "otr_pr_$3"
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 .env
 .env.*
 !.env.example
+app.env
 
 # vercel
 .vercel

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,64 @@
+# Shared dev tier: database and queue only, used by every PR preview stack.
+# Preview stacks attach to the `otr-dev` network and reach these by alias.
+name: otr-dev
+
+services:
+  db:
+    # otr-scripts recovery runs `docker compose stop db` in this directory,
+    # so this service must stay named `db`.
+    image: postgres:17
+    container_name: otr-dev-db
+    restart: unless-stopped
+    shm_size: '256m'
+    ports:
+      - '5632:5432'
+    environment:
+      POSTGRES_USER: ${DOCKER_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${DOCKER_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${DOCKER_POSTGRES_DB}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      otr-dev:
+        aliases:
+          - otr-dev-db
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'pg_isready -U ${DOCKER_POSTGRES_USER} -d ${DOCKER_POSTGRES_DB}',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+
+  rabbitmq:
+    image: rabbitmq:4-management
+    container_name: otr-dev-rabbitmq
+    restart: unless-stopped
+    ports:
+      - '5872:5672'
+      - '15872:15672'
+    environment:
+      RABBITMQ_DEFAULT_USER: ${DOCKER_RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${DOCKER_RABBITMQ_PASSWORD}
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      otr-dev:
+        aliases:
+          - otr-dev-rabbitmq
+    healthcheck:
+      test: ['CMD-SHELL', 'rabbitmq-diagnostics -q ping']
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+networks:
+  otr-dev:
+    name: otr-dev
+
+volumes:
+  postgres-data:
+  rabbitmq-data:

--- a/docker-compose-preview.yml
+++ b/docker-compose-preview.yml
@@ -1,0 +1,73 @@
+# Per-PR preview stack: website and its tailnet endpoint only.
+# The database and queue come from the shared dev tier (docker-compose-dev.yml);
+# the data worker deliberately does not run here, so previews make no osu! API
+# calls. Deploy with a per-PR project name: `docker compose -p otr-pr-<n> up -d`.
+# No service may declare container_name or previews would collide.
+
+services:
+  web:
+    image: stagecodes/otr-web:${IMAGE_TAG}
+    restart: unless-stopped
+    # app.env holds application config; .env holds the values Compose
+    # interpolates below, including the Tailscale credentials.
+    env_file:
+      - ./app.env
+    environment:
+      DATABASE_URL: ${PREVIEW_DATABASE_URL}
+      RABBITMQ_AMQP_URL: ${PREVIEW_RABBITMQ_URL}
+      BETTER_AUTH_URL: ${PREVIEW_URL}
+      NEXT_PUBLIC_APP_BASE_URL: ${PREVIEW_URL}
+      E2E_TEST_AUTH: 'true'
+      MAINTENANCE_WINDOW_ENABLED: 'false'
+    networks:
+      - default
+      - otr-dev
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'bun -e "fetch(\"http://localhost:3000/api/health\").then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # Only for PRs that add migrations, which run against their own cloned
+  # database. Never run this against the shared dev database.
+  migrate:
+    image: stagecodes/otr-web:${IMAGE_TAG}
+    profiles:
+      - migrate
+    restart: 'no'
+    env_file:
+      - ./app.env
+    environment:
+      DATABASE_URL: ${PREVIEW_DATABASE_URL}
+    command: ['./scripts/run-migrations.sh']
+    networks:
+      - otr-dev
+
+  tailscale:
+    image: tailscale/tailscale:latest
+    restart: unless-stopped
+    environment:
+      # OAuth client credentials mint an ephemeral node, so the tailnet entry
+      # removes itself when the stack comes down.
+      TS_CLIENT_ID: ${TS_CLIENT_ID}
+      TS_CLIENT_SECRET: ${TS_CLIENT_SECRET}
+      TS_HOSTNAME: ${PREVIEW_HOSTNAME}
+      TS_EXTRA_ARGS: --advertise-tags=tag:preview
+      TS_SERVE_CONFIG: /config/serve.json
+      TS_STATE_DIR: /tmp/tailscale
+    volumes:
+      # Must be a directory; Tailscale watches it for changes.
+      - ./ts-config:/config
+    depends_on:
+      - web
+    networks:
+      - default
+
+networks:
+  otr-dev:
+    external: true

--- a/preview/README.md
+++ b/preview/README.md
@@ -1,0 +1,70 @@
+# PR previews
+
+Label a PR `preview` and it deploys to `https://otr-pr-<number>.<tailnet>.ts.net`,
+private to the tailnet. Closing the PR removes the stack, its database clone, and
+the tailnet node.
+
+Previews run the website only. The database and queue come from the shared dev
+tier (`docker-compose-dev.yml`), and there is no data worker, so previews make no
+osu! API calls.
+
+## Logging in
+
+osu! OAuth registers a single redirect URI, so it cannot work on per-PR
+hostnames. Previews set `E2E_TEST_AUTH=true` instead; mint a session with:
+
+```
+curl -X POST https://otr-pr-<number>.<tailnet>.ts.net/api/auth/e2e/sign-in \
+  -H 'content-type: application/json' \
+  -d '{"playerId": 1, "admin": true}'
+```
+
+The endpoint is unauthenticated, which is why previews stay off the public
+internet.
+
+## Databases
+
+`otr_dev_seed` is restored from the otr-scripts dev replica, migrated up to the
+default branch, and left idle; `otr_dev` is rebuilt from it and shared by every
+preview. PRs that touch `apps/web/drizzle` get their own clone so they never
+migrate the shared schema. Every deploy health-checks `otr_dev` first and
+restores it if the check fails.
+
+The seed migration uses `stagecodes/otr-web:staging-latest`, which tracks the
+default branch; override with `DEV_MIGRATION_IMAGE`.
+
+Previews share mutable state — one PR's admin actions change what another shows,
+and the nightly refresh discards all of it.
+
+## One-time setup
+
+Tailnet: enable HTTPS certificates, add a `tag:preview` entry to `tagOwners`, and
+grant the CI OAuth client permission to that tag.
+
+`dev` GitHub environment:
+
+| Secret                  | Purpose                                                |
+| ----------------------- | ------------------------------------------------------ |
+| `DEV_ENV`               | Compose variables for the dev tier                     |
+| `PREVIEW_ENV`           | Application config for preview web containers          |
+| `PREVIEW_DB_URL_PREFIX` | e.g. `postgresql://postgres:password@otr-dev-db:5432/` |
+| `PREVIEW_RABBITMQ_URL`  | e.g. `amqp://admin:admin@otr-dev-rabbitmq:5672/`       |
+| `DEV_REMOTE_PATH`       | Dev tier directory on the host                         |
+| `PREVIEW_REMOTE_PATH`   | Parent directory for preview stacks                    |
+| `OTR_SCRIPTS_DIR`       | otr-scripts checkout on the host                       |
+
+`TS_TAILNET` is a repository variable (`example-tailnet.ts.net`). `SSH_USER`,
+`SSH_HOST`, `TS_OAUTH_*`, and `DOCKERHUB_*` are already configured for deploys.
+
+`PREVIEW_ENV` must set `E2E_TEST_AUTH=true` and `MAINTENANCE_WINDOW_ENABLED=false`,
+carry a fresh `BETTER_AUTH_SECRET`, and use placeholder osu! credentials — the
+real ones are never needed here.
+
+The dev tier needs its own otr-scripts `.env` on the host with `OTR_WEB_DIR`
+pointing at the dev tier directory, `DB_CONTAINER=otr-dev-db`, `DB_PORT=5632`,
+`DB_NAME=otr_dev_seed`, and `ENVIRONMENT=dev`. Recovery runs
+`docker compose stop db` in `OTR_WEB_DIR`; pointing it at the production
+directory would stop production.
+
+Deploy the tier with the `Dev tier` workflow (`deploy`), which also refreshes the
+replica nightly.

--- a/preview/ts-config/serve.json
+++ b/preview/ts-config/serve.json
@@ -1,0 +1,9 @@
+{
+  "TCP": { "443": { "HTTPS": true } },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": { "/": { "Proxy": "http://web:3000" } }
+    }
+  },
+  "AllowFunnel": { "${TS_CERT_DOMAIN}:443": false }
+}

--- a/scripts/preview/dev-db.sh
+++ b/scripts/preview/dev-db.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Manages the shared dev-tier database that PR previews read from.
+#
+#   check          verify the live database is usable
+#   restore        restore the dev replica into the seed, then rebuild live
+#   clone <db>     create <db> from the seed, for PRs that add migrations
+#   drop <db>      remove a cloned database
+#
+# Configuration comes from the environment; see preview/README.md.
+
+CONTAINER="${DEV_DB_CONTAINER:-otr-dev-db}"
+DB_USER="${DEV_DB_USER:-postgres}"
+SEED_DB="${DEV_SEED_DB:-otr_dev_seed}"
+LIVE_DB="${DEV_LIVE_DB:-otr_dev}"
+OTR_SCRIPTS_DIR="${OTR_SCRIPTS_DIR:-/srv/otr-scripts}"
+MAX_STALE_DAYS="${DEV_DB_MAX_STALE_DAYS:-14}"
+EXPECTED_MIGRATIONS="${EXPECTED_MIGRATIONS:-}"
+DB_URL_PREFIX="${DEV_DB_URL_PREFIX:-postgresql://postgres:password@otr-dev-db:5432/}"
+# staging-latest is rebuilt on every push to the default branch.
+MIGRATION_IMAGE="${DEV_MIGRATION_IMAGE:-stagecodes/otr-web:staging-latest}"
+NETWORK="${DEV_NETWORK:-otr-dev}"
+
+# Minimum rows for the replica to be considered intact, set near half of
+# current production so a truncated restore fails but ordinary drift does not.
+ROW_FLOORS=(
+  "players:50000"
+  "tournaments:1500"
+  "matches:75000"
+  "games:500000"
+  "game_scores:2000000"
+  "rating_adjustments:2000000"
+)
+
+query() { # query <database> <sql>
+  docker exec -i "$CONTAINER" psql -U "$DB_USER" -d "$1" -tAc "$2"
+}
+
+fail() {
+  echo "dev-db check failed: $1" >&2
+  exit 1
+}
+
+database_exists() {
+  [[ "$(query postgres "select 1 from pg_database where datname='$1'")" == "1" ]]
+}
+
+# DROP DATABASE and CREATE ... TEMPLATE both require zero connections.
+disconnect() {
+  query postgres "select pg_terminate_backend(pid) from pg_stat_activity
+    where datname='$1' and pid <> pg_backend_pid()" >/dev/null
+}
+
+check() {
+  docker exec "$CONTAINER" pg_isready -U "$DB_USER" >/dev/null 2>&1 ||
+    fail "postgres is not accepting connections"
+
+  database_exists "$LIVE_DB" || fail "database $LIVE_DB does not exist"
+
+  if [[ -n "$EXPECTED_MIGRATIONS" ]]; then
+    local applied
+    applied="$(query "$LIVE_DB" 'select count(*) from drizzle.__drizzle_migrations')"
+    [[ "$applied" == "$EXPECTED_MIGRATIONS" ]] ||
+      fail "applied migrations $applied, expected $EXPECTED_MIGRATIONS"
+  fi
+
+  # A restore that dies partway still loads rows, so verify the constraints
+  # that only get added once the data is fully in.
+  local constraints
+  constraints="$(query "$LIVE_DB" "select count(*) from pg_constraint
+    where contype='f' and conrelid='matches'::regclass")"
+  [[ "$constraints" -gt 0 ]] || fail "matches has no foreign keys; restore was incomplete"
+
+  local entry table floor actual
+  for entry in "${ROW_FLOORS[@]}"; do
+    table="${entry%%:*}"
+    floor="${entry##*:}"
+    actual="$(query "$LIVE_DB" "select count(*) from $table")"
+    [[ "$actual" -ge "$floor" ]] || fail "$table has $actual rows, expected at least $floor"
+  done
+
+  local stale
+  stale="$(query "$LIVE_DB" "select coalesce(max(created), 'epoch') <
+    now() - interval '$MAX_STALE_DAYS days' from matches")"
+  [[ "$stale" == "f" ]] || fail "newest match is older than $MAX_STALE_DAYS days"
+
+  echo "dev-db check passed"
+}
+
+restore() {
+  echo "restoring $SEED_DB from the dev replica"
+  # --db-only keeps this to the dev tier's own db container. The scoping that
+  # keeps it off production lives in the otr-scripts .env: OTR_WEB_DIR must
+  # point at the dev tier directory and DB_NAME at the seed.
+  (cd "$OTR_SCRIPTS_DIR" && uv run python src/main.py \
+    --script recovery --recovery-bucket dev --db-only)
+
+  database_exists "$SEED_DB" || fail "restore did not produce $SEED_DB"
+
+  # The replica carries whatever schema production is on, which can trail the
+  # default branch. Previews run branch code, so bring the seed forward before
+  # anything clones from it.
+  echo "migrating $SEED_DB"
+  docker run --rm --network "$NETWORK" \
+    -e DATABASE_URL="${DB_URL_PREFIX}${SEED_DB}" \
+    "$MIGRATION_IMAGE" ./scripts/run-migrations.sh
+
+  echo "rebuilding $LIVE_DB from $SEED_DB"
+  disconnect "$LIVE_DB"
+  query postgres "drop database if exists $LIVE_DB" >/dev/null
+  disconnect "$SEED_DB"
+  query postgres "create database $LIVE_DB template $SEED_DB" >/dev/null
+  echo "rebuilt $LIVE_DB"
+}
+
+clone() {
+  local target="$1"
+  disconnect "$target"
+  query postgres "drop database if exists $target" >/dev/null
+  disconnect "$SEED_DB"
+  query postgres "create database $target template $SEED_DB" >/dev/null
+  echo "created $target from $SEED_DB"
+}
+
+drop() {
+  local target="$1"
+  disconnect "$target"
+  query postgres "drop database if exists $target" >/dev/null
+  echo "dropped $target"
+}
+
+case "${1:-}" in
+  check) check ;;
+  restore) restore ;;
+  clone) clone "${2:?database name required}" ;;
+  drop) drop "${2:?database name required}" ;;
+  *)
+    echo "usage: $0 {check|restore|clone <db>|drop <db>}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
- Adds `docker-compose-dev.yml`, a shared dev tier of Postgres and RabbitMQ.
- Adds `docker-compose-preview.yml`, a per-PR website plus Tailscale sidecar. No data worker.
- Adds `scripts/preview/dev-db.sh` with `check`, `restore`, `clone`, `drop`.
- Adds `preview.yml` and `dev-tier.yml` workflows.
- Clones a per-PR database when a PR touches `apps/web/drizzle`.

Previews use `E2E_TEST_AUTH`, not osu! login. Labelled same-repo PRs only; forks get no secrets. Nothing here has run against real infrastructure.

## Todo

- [x] Remove `public.users` from the otr-scripts dev blacklist, or restores fail on ~290k foreign keys
- [ ] Add the `dev` environment secrets listed in `preview/README.md`
- [ ] Add `tag:preview` to tailnet `tagOwners` and grant the CI OAuth client
- [ ] Enable tailnet HTTPS certificates
- [ ] Add the `TS_TAILNET` repository variable
- [ ] Write the dev tier otr-scripts `.env` on the host, scoped to the dev compose directory
- [ ] Create the `preview` label
- [ ] Pin the `tailscale/tailscale` image version
- [ ] Run `Dev tier` with `deploy`, then label a PR to verify
